### PR TITLE
Adding hand-relative movement options.

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -663,7 +663,7 @@ void Game::PostThrowGrenade(HaloID& playerID)
 
 void Game::UpdateInputs()
 {
-	inputHandler.UpdateInputs();
+	inputHandler.UpdateInputs(bInVehicle);
 }
 
 

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -768,6 +768,8 @@ void Game::SetupConfigs()
 	c_SnapTurn = config.RegisterBool("SnapTurn", "The look input will instantly rotate the view by a fixed amount, rather than smoothly rotating", true);
 	c_SnapTurnAmount = config.RegisterFloat("SnapTurnAmount", "Rotation in degrees a single snap turn will rotate the view by", 45.0f);
 	c_SmoothTurnAmount = config.RegisterFloat("SmoothTurnAmount", "Rotation in degrees per second the view will turn at when not using snap turning", 90.0f);
+	c_HandRelativeMovement = config.RegisterInt("HandRelativeMovement", "Movement is relative to hand orientation, rather than head, 0 = off, 1 = left, 2 = right", 0);
+	c_HandRelativeOffsetRotation = config.RegisterFloat("HandRelativeOffsetRotation", "Hand direction rotational offset in degrees used for hand-relative movement", -20.0f);
 	c_HorizontalVehicleTurnAmount = config.RegisterFloat("HorizontalVehicleTurnAmount", "Rotation in degrees per second the view will turn horizontally when in vehicles", 90.0f);
 	c_VerticalVehicleTurnAmount = config.RegisterFloat("VerticalVehicleTurnAmount", "Rotation in degrees per second the view will turn vertically when in vehicles", 45.0f);
 	c_ToggleGrip = config.RegisterBool("ToggleGrip", "When true releasing two handed weapons requires pressing the grip action again", false);

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -172,6 +172,8 @@ public:
 	BoolProperty* c_SnapTurn = nullptr;
 	FloatProperty* c_SnapTurnAmount = nullptr;
 	FloatProperty* c_SmoothTurnAmount = nullptr;
+	IntProperty* c_HandRelativeMovement = nullptr;
+	FloatProperty* c_HandRelativeOffsetRotation = nullptr;
 	FloatProperty* c_HorizontalVehicleTurnAmount = nullptr;
 	FloatProperty* c_VerticalVehicleTurnAmount = nullptr;
 	FloatProperty* c_LeftHandFlashlightDistance = nullptr;

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -33,6 +33,24 @@ void InputHandler::RegisterInputs()
 	RegisterVector2Input(Look);
 }
 
+float AngleBetweenVector2(const Vector2& v1, const Vector2& v2)
+{
+	const float dot = v1.dot(v2);
+	const float determinant = v1.x * v2.y - v1.y * v2.x;
+	const float angle = atan2(determinant, dot);
+	return angle;
+}
+
+Vector2 RotateVector2(const Vector2& v, float angle)
+{
+	Vector2 rotated;
+	rotated.x = v.x * cos(angle) - v.y * sin(angle);
+	rotated.y = v.x * sin(angle) + v.y * cos(angle);
+	return rotated;
+}
+
+#define DRAW_DEBUG_MOVE 0
+
 void InputHandler::UpdateInputs()
 {
 	IVR* vr = Game::instance.GetVR();
@@ -151,6 +169,41 @@ void InputHandler::UpdateInputs()
 	Game::instance.bUseTwoHandAim = bIsGripping;
 
 	Vector2 MoveInput = vr->GetVector2Input(Move);
+
+	if (Game::instance.c_HandRelativeMovement->Value())
+	{
+		Camera& cam = Helpers::GetCamera();
+		Vector3 camForward = cam.lookDir;
+
+		const bool leftHand = (Game::instance.c_HandRelativeMovement->Value() == 1);
+		const ControllerRole role = leftHand ? ControllerRole::Left : ControllerRole::Right;
+		Matrix4 controllerTransform = vr->GetControllerTransform(role); // TODO: Not sure about bRenderPose bool param here. Doesn't seem to matter.
+		const float offset = Game::instance.c_HandRelativeOffsetRotation->Value();
+		controllerTransform.rotateZ(leftHand ? offset: -offset);
+		Vector3 handForward = controllerTransform.getLeftAxis();
+
+#if DRAW_DEBUG_MOVE
+		Vector3 start = cam.position + cam.lookDirUp * -Game::instance.MetresToWorld(0.1f);
+		Game::instance.inGameRenderer.DrawLine3D(start, start + camForward * Game::instance.MetresToWorld(2.0f), D3DCOLOR_ARGB(255, 255, 0, 0), false, 0.5f);
+		Game::instance.inGameRenderer.DrawLine3D(start, start + handForward * Game::instance.MetresToWorld(2.0f), D3DCOLOR_ARGB(255, 0, 0, 255), false, 0.5f);
+		handForward.z = camForward.z = 0.0f;
+		Game::instance.inGameRenderer.DrawLine3D(start, start + camForward * Game::instance.MetresToWorld(2.0f), D3DCOLOR_ARGB(255, 255, 75, 0), false, 0.5f);
+		Game::instance.inGameRenderer.DrawLine3D(start, start + handForward * Game::instance.MetresToWorld(2.0f), D3DCOLOR_ARGB(255, 100, 0, 255), false, 0.5f);
+
+		start = cam.position + cam.lookDir * Game::instance.MetresToWorld(2.00f);
+		const Vector3 camRight = cam.lookDir.cross(cam.lookDirUp);
+		Vector3 end = start + cam.lookDirUp * MoveInput.y * Game::instance.MetresToWorld(1.0f) + camRight * MoveInput.x * Game::instance.MetresToWorld(1.0f);
+		Game::instance.inGameRenderer.DrawLine3D(start, end, D3DCOLOR_ARGB(255, 0, 255, 0), false, 0.5f);
+#endif
+
+		const float angle = AngleBetweenVector2(Vector2(camForward.x, camForward.y), Vector2(handForward.x, handForward.y));
+		MoveInput = RotateVector2(MoveInput, angle);
+
+#if DRAW_DEBUG_MOVE
+		end = start + cam.lookDirUp * MoveInput.y * Game::instance.MetresToWorld(1.0f) + camRight * MoveInput.x * Game::instance.MetresToWorld(1.0f);
+		Game::instance.inGameRenderer.DrawLine3D(start, end, D3DCOLOR_ARGB(255, 255, 255, 0), false, 0.5f);
+#endif
+	}
 
 	controls.Left = -MoveInput.x;
 	controls.Forwards = MoveInput.y;

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -51,7 +51,7 @@ Vector2 RotateVector2(const Vector2& v, float angle)
 
 #define DRAW_DEBUG_MOVE 0
 
-void InputHandler::UpdateInputs()
+void InputHandler::UpdateInputs(bool bInVehicle)
 {
 	IVR* vr = Game::instance.GetVR();
 
@@ -170,7 +170,7 @@ void InputHandler::UpdateInputs()
 
 	Vector2 MoveInput = vr->GetVector2Input(Move);
 
-	if (Game::instance.c_HandRelativeMovement->Value())
+	if (!bInVehicle && (Game::instance.c_HandRelativeMovement->Value() != 0))
 	{
 		Camera& cam = Helpers::GetCamera();
 		Vector3 camForward = cam.lookDir;

--- a/HaloCEVR/InputHandler.h
+++ b/HaloCEVR/InputHandler.h
@@ -6,7 +6,7 @@ class InputHandler
 {
 public:
 	void RegisterInputs();
-	void UpdateInputs();
+	void UpdateInputs(bool bInVehicle);
 	void UpdateCamera(float& yaw, float& pitch);
 	void UpdateCameraForVehicles(float& yaw, float& pitch);
 	void SetMousePosition(int& x, int& y);


### PR DESCRIPTION
Added new options for hand-relative movement.

HandRelativeMovement:
[Int] Movement is relative to hand orientation, rather than head, 0 = off, 1 = left, 2 = right (Default Value: 0)

HandRelativeOffsetRotation:
[Float] Hand direction rotational offset in degrees used for hand-relative movement (Default Value: -20)

Tested with left and right hand, and with two-handed weapon grip. Seems to work OK.

Wanted this for myself, but maybe others can make use of it.