### PR TITLE
Added basic weapon movement smoothing

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -788,6 +788,7 @@ void Game::SetupConfigs()
 	// Misc settings
 	c_ShowRoomCentre = config.RegisterBool("ShowRoomCentre", "Draw an indicator at your feet to show where the player character is actually positioned", true);
 	c_d3d9Path = config.RegisterString("CustomD3D9Path", "If set first try to load d3d9.dll from the specified path instead of from system32", "");
+	c_WeaponSmoothingAmount = config.RegisterFloat("WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement (0 is disabled, 1 is maximum, recommended around 0.2-0.5)", 0.0f);
 
 	config.LoadFromFile("VR/config.txt");
 	config.SaveToFile("VR/config.txt");

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -664,6 +664,20 @@ void Game::UpdateInputs()
 	inputHandler.UpdateInputs(bInVehicle);
 }
 
+void Game::CalculateSmoothedInput()
+{
+	inputHandler.CalculateSmoothedInput(); 
+}
+
+bool Game::GetCalculatedHandPositions(Matrix4& controllerTransform, Vector3& dominantHandPos, Vector3& offHand)
+{
+	return inputHandler.GetCalculatedHandPositions(controllerTransform, dominantHandPos, offHand);
+}
+
+Vector3 Game::GetSmoothedInput()
+{
+	return inputHandler.smoothedPosition;
+}
 
 void Game::UpdateCamera(float& yaw, float& pitch)
 {
@@ -790,7 +804,7 @@ void Game::SetupConfigs()
 	c_d3d9Path = config.RegisterString("CustomD3D9Path", "If set first try to load d3d9.dll from the specified path instead of from system32", "");
 	c_WeaponSmoothingAmountNoZoom = config.RegisterFloat("UnzoomedWeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when not zoomed in (0 is disabled, 1 is maximum, recommended around 0-0.2)", 0.0f);
 	c_WeaponSmoothingAmountOneZoom = config.RegisterFloat("Zoom1WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in once, eg zooming on the pistol (0 is disabled, 1 is maximum, recommended around 0.3-0.5)", 0.4f);
-	c_WeaponSmoothingAmountTwoZoom = config.RegisterFloat("Zoom2WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in twice, eg second zoom on sniper (0 is disabled, 1 is maximum, recommended around 0.6-1)", 0.85f);
+	c_WeaponSmoothingAmountTwoZoom = config.RegisterFloat("Zoom2WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in twice, eg second zoom on sniper (0 is disabled, 1 is maximum, recommended around 0.6-1)", 0.6f);
 
 	config.LoadFromFile("VR/config.txt");
 	config.SaveToFile("VR/config.txt");

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -788,7 +788,9 @@ void Game::SetupConfigs()
 	// Misc settings
 	c_ShowRoomCentre = config.RegisterBool("ShowRoomCentre", "Draw an indicator at your feet to show where the player character is actually positioned", true);
 	c_d3d9Path = config.RegisterString("CustomD3D9Path", "If set first try to load d3d9.dll from the specified path instead of from system32", "");
-	c_WeaponSmoothingAmount = config.RegisterFloat("WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement (0 is disabled, 1 is maximum, recommended around 0.2-0.5)", 0.0f);
+	c_WeaponSmoothingAmountNoZoom = config.RegisterFloat("UnzoomedWeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when not zoomed in (0 is disabled, 1 is maximum, recommended around 0-0.2)", 0.0f);
+	c_WeaponSmoothingAmountOneZoom = config.RegisterFloat("Zoom1WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in once, eg zooming on the pistol (0 is disabled, 1 is maximum, recommended around 0.3-0.5)", 0.4f);
+	c_WeaponSmoothingAmountTwoZoom = config.RegisterFloat("Zoom2WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in twice, eg second zoom on sniper (0 is disabled, 1 is maximum, recommended around 0.6-1)", 0.85f);
 
 	config.LoadFromFile("VR/config.txt");
 	config.SaveToFile("VR/config.txt");

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -32,6 +32,7 @@ public:
 	void PreDrawMirror(struct Renderer* renderer, float deltaTime);
 	void PostDrawMirror(struct Renderer* renderer, float deltaTime);
 	void PostDrawFrame(struct Renderer* renderer, float deltaTime);
+	Vector3 GetSmoothedInput();
 
 	bool PreDrawHUD();
 	void PostDrawHUD();
@@ -53,8 +54,11 @@ public:
 	void PostFireWeapon(HaloID& WeaponID, short param2);
 	void PreThrowGrenade(HaloID& playerID);
 	void PostThrowGrenade(HaloID& playerID);
+	bool GetCalculatedHandPositions(Matrix4& controllerTransform, Vector3& dominantHandPos, Vector3& offHand); 
 
 	void UpdateInputs();
+	void CalculateSmoothedInput();
+
 	void UpdateCamera(float& yaw, float& pitch);
 	void SetMousePosition(int& x, int& y);
 	void UpdateMouseInfo(struct MouseInfo* mouseInfo);
@@ -196,6 +200,5 @@ public:
 	FloatProperty* c_WeaponSmoothingAmountNoZoom = nullptr;
 	FloatProperty* c_WeaponSmoothingAmountOneZoom = nullptr;
 	FloatProperty* c_WeaponSmoothingAmountTwoZoom = nullptr;
-
 };
 

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -193,5 +193,6 @@ public:
 	BoolProperty* c_ToggleGrip = nullptr;
 	BoolProperty* c_LeftHanded = nullptr;
 	StringProperty* c_d3d9Path = nullptr;
+	FloatProperty* c_WeaponSmoothingAmount = nullptr;
 };
 

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -193,6 +193,9 @@ public:
 	BoolProperty* c_ToggleGrip = nullptr;
 	BoolProperty* c_LeftHanded = nullptr;
 	StringProperty* c_d3d9Path = nullptr;
-	FloatProperty* c_WeaponSmoothingAmount = nullptr;
+	FloatProperty* c_WeaponSmoothingAmountNoZoom = nullptr;
+	FloatProperty* c_WeaponSmoothingAmountOneZoom = nullptr;
+	FloatProperty* c_WeaponSmoothingAmountTwoZoom = nullptr;
+
 };
 

--- a/HaloCEVR/Helpers/Maths.cpp
+++ b/HaloCEVR/Helpers/Maths.cpp
@@ -117,3 +117,9 @@ void Helpers::CombineTransforms(const Transform* transformA, const Transform* tr
 		(transformA->translation).z;
 	outTransform->scale = transformA->scale * transformB->scale;
 }
+
+
+Vector3 Helpers::Lerp(const Vector3& a, const Vector3& b, float t)
+{
+	return a + t * (b - a);
+}

--- a/HaloCEVR/Helpers/Maths.h
+++ b/HaloCEVR/Helpers/Maths.h
@@ -20,4 +20,5 @@ namespace Helpers
 	void MakeTransformFromXZ(const Vector3* facingVector, const Vector3* upVector, Transform* outTransform);
 	void MakeTransformFromQuat(const Vector4* quaternion, Transform* outTransform);
 	void CombineTransforms(const Transform* transformA, const Transform* transformB, Transform* outTransform);
+	Vector3 Lerp(const Vector3& a, const Vector3& b, float t);
 }

--- a/HaloCEVR/Hooking/Hooks.cpp
+++ b/HaloCEVR/Hooking/Hooks.cpp
@@ -588,6 +588,7 @@ void Hooks::H_HandleInputs()
 	HandleInputs.Original();
 
 	Game::instance.UpdateInputs();
+	Game::instance.CalculateSmoothedInput(); 
 }
 
 void __declspec(naked) Hooks::H_UpdatePitchYaw()

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -391,6 +391,74 @@ void InputHandler::UpdateMouseInfo(MouseInfo* mouseInfo)
 	mouseInfo->buttonState[0] = mouseDownState;
 }
 
+bool InputHandler::GetCalculatedHandPositions(Matrix4& controllerTransform, Vector3& dominantHandPos, Vector3& offHand)
+{
+	ControllerRole dominant = Game::instance.c_LeftHanded->Value() ? ControllerRole::Left : ControllerRole::Right;
+	ControllerRole nonDominant = Game::instance.c_LeftHanded->Value() ? ControllerRole::Right : ControllerRole::Left;
+
+	controllerTransform = Game::instance.GetVR()->GetControllerTransform(dominant, true);
+
+	Vector3 poseDirection;
+	bool bHasPoseData = Game::instance.GetVR()->TryGetControllerFacing(dominant, poseDirection);
+
+	// When 2h aiming point the main hand at the offhand 
+	if (Game::instance.bUseTwoHandAim || bHasPoseData)
+	{
+		Matrix4 aimingTransform = Game::instance.GetVR()->GetRawControllerTransform(dominant, true);
+		Matrix4 offHandTransform = Game::instance.GetVR()->GetRawControllerTransform(nonDominant, true);
+
+		const Vector3 actualControllerPos = controllerTransform * Vector3(0.0f, 0.0f, 0.0f);
+		const Vector3 mainHandPos = aimingTransform * Vector3(0.0f, 0.0f, 0.0f);
+		const Vector3 offHandPos = Game::instance.bUseTwoHandAim ? offHandTransform * Vector3(0.0f, 0.0f, 0.0f) : mainHandPos + poseDirection;
+		const Vector3 toOffHand = (offHandPos - mainHandPos).normalize();
+
+		dominantHandPos = actualControllerPos; 
+		offHand = toOffHand; 
+
+		return true; 
+	}
+
+	return false; 
+}
+
+void InputHandler::CalculateSmoothedInput()
+{
+	Matrix4 controllerTransform;
+	Vector3 actualControllerPos;
+	Vector3 toOffHand;
+
+	if (!GetCalculatedHandPositions(controllerTransform, actualControllerPos, toOffHand))
+	{
+		return;
+	}
+
+	float userInput = 0.0f;
+	short zoom = Helpers::GetInputData().zoomLevel;
+
+	if (zoom == -1)
+	{
+		userInput = Game::instance.c_WeaponSmoothingAmountNoZoom->Value();
+	}
+	else if (zoom == 0)
+	{
+		userInput = Game::instance.c_WeaponSmoothingAmountOneZoom->Value();
+	}
+	else if (zoom == 1)
+	{
+		userInput = Game::instance.c_WeaponSmoothingAmountTwoZoom->Value();
+	}
+
+	float clampedValue = std::clamp(userInput, 0.0f, 1.0f);
+
+	float maxSmoothing = 20.0f;		//20 is already a bit ridiculous but just incase people need that much smoothing. 
+	float speedRampup = 10.0f;		//This helps control the slowdown curve of the interpolation
+
+	// Apply the smoothing using linear interpolation with the adjusted deltaTime
+	float t = (clampedValue * maxSmoothing) * Game::instance.lastDeltaTime;
+	smoothedPosition = Helpers::Lerp(smoothedPosition, actualControllerPos + toOffHand, exp(-t * speedRampup));
+}
+
+
 #undef ApplyBoolInput
 #undef ApplyImpulseBoolInput
 #undef RegisterBoolInput

--- a/HaloCEVR/InputHandler.h
+++ b/HaloCEVR/InputHandler.h
@@ -11,6 +11,10 @@ public:
 	void UpdateCameraForVehicles(float& yaw, float& pitch);
 	void SetMousePosition(int& x, int& y);
 	void UpdateMouseInfo(struct MouseInfo* mouseInfo);
+	bool GetCalculatedHandPositions(Matrix4& controllerTransform, Vector3& dominantHandPos, Vector3& offHand);
+	void CalculateSmoothedInput(); 
+
+	Vector3 smoothedPosition = Vector3(0.0f, 0.0f, 0.0f);
 
 protected:
 

--- a/HaloCEVR/WeaponHandler.cpp
+++ b/HaloCEVR/WeaponHandler.cpp
@@ -643,7 +643,22 @@ Matrix4 WeaponHandler::GetDominantHandTransform() const
 		}
 		*/
 
-		float userInput = Game::instance.c_WeaponSmoothingAmount->Value();
+		float userInput = 0.0f;
+		short zoom = Helpers::GetInputData().zoomLevel; 
+		
+		if (zoom == -1)
+		{
+			userInput = Game::instance.c_WeaponSmoothingAmountNoZoom->Value(); 
+		}
+		else if (zoom == 0)
+		{
+			userInput = Game::instance.c_WeaponSmoothingAmountOneZoom->Value();
+		}
+		else if (zoom == 1)
+		{
+			userInput = Game::instance.c_WeaponSmoothingAmountTwoZoom->Value();
+		}
+
 		float clampedValue = std::clamp(userInput, 0.0f, 1.0f);
 
 		float maxSmoothing = 20.0f;		//20 is already a bit ridiculous but just incase people need that much smoothing. 

--- a/HaloCEVR/WeaponHandler.cpp
+++ b/HaloCEVR/WeaponHandler.cpp
@@ -650,7 +650,7 @@ Matrix4 WeaponHandler::GetDominantHandTransform() const
 		float clampedValue = std::clamp(userInput, 0.0f, 0.9f);	
 		float smoothFactor = (1 - clampedValue) * maxSmoothing;
 
-		smoothedPosition = clampedValue == 0 ? actualControllerPos + toOffHand : WeaponHandler::Lerp(smoothedPosition, actualControllerPos + toOffHand, smoothFactor * Game::instance.lastDeltaTime);
+		smoothedPosition = clampedValue == 0 ? actualControllerPos + toOffHand : Helpers::Lerp(smoothedPosition, actualControllerPos + toOffHand, smoothFactor * Game::instance.lastDeltaTime);
 		controllerTransform.lookAt(smoothedPosition, upVector);
 
 		controllerTransform.translate(-actualControllerPos);
@@ -888,9 +888,4 @@ void WeaponHandler::PostThrowGrenade(HaloID& playerID)
 		weaponFiredPlayer->aim = realPlayerAim;
 		weaponFiredPlayer = nullptr;
 	}
-}
-
-Vector3 WeaponHandler::Lerp(const Vector3& a, const Vector3& b, float t) const
-{
-	return a + t * (b - a);
 }

--- a/HaloCEVR/WeaponHandler.cpp
+++ b/HaloCEVR/WeaponHandler.cpp
@@ -644,13 +644,15 @@ Matrix4 WeaponHandler::GetDominantHandTransform() const
 		*/
 
 		float userInput = Game::instance.c_WeaponSmoothingAmount->Value();
-		float maxSmoothing = 15.0f;		//15 is already a bit ridiculous but just incase people need that much smoothing. 
+		float clampedValue = std::clamp(userInput, 0.0f, 1.0f);
 
-		//A value of 0 causes weapons to invert so have just above. 
-		float clampedValue = std::clamp(userInput, 0.0f, 0.9f);	
-		float smoothFactor = (1 - clampedValue) * maxSmoothing;
+		float maxSmoothing = 20.0f;		//20 is already a bit ridiculous but just incase people need that much smoothing. 
+		float speedRampup = 10.0f;		//This helps control the slowdown curve of the interpolation
 
-		smoothedPosition = clampedValue == 0 ? actualControllerPos + toOffHand : Helpers::Lerp(smoothedPosition, actualControllerPos + toOffHand, smoothFactor * Game::instance.lastDeltaTime);
+		float t = (clampedValue * maxSmoothing) * Game::instance.lastDeltaTime;
+
+		// Apply the smoothing using linear interpolation with the adjusted deltaTime
+		smoothedPosition = Helpers::Lerp(smoothedPosition, actualControllerPos + toOffHand, exp(-t * speedRampup));
 		controllerTransform.lookAt(smoothedPosition, upVector);
 
 		controllerTransform.translate(-actualControllerPos);

--- a/HaloCEVR/WeaponHandler.h
+++ b/HaloCEVR/WeaponHandler.h
@@ -45,7 +45,6 @@ protected:
 	inline Vector3 GetScopeLocation(ScopedWeaponType Type) const;
 
 	Matrix4 GetDominantHandTransform() const;
-	Vector3 Lerp(const Vector3& a, const Vector3& b, float t) const;
 
 	struct ViewModelCache
 	{

--- a/HaloCEVR/WeaponHandler.h
+++ b/HaloCEVR/WeaponHandler.h
@@ -45,6 +45,7 @@ protected:
 	inline Vector3 GetScopeLocation(ScopedWeaponType Type) const;
 
 	Matrix4 GetDominantHandTransform() const;
+	Vector3 Lerp(const Vector3& a, const Vector3& b, float t) const;
 
 	struct ViewModelCache
 	{


### PR DESCRIPTION
Weapon movement is now smoothed out. Modify in the config file using value "WeaponSmoothingAmount". 0 is disabled, 1 is maximum smoothing. Smoothing defaults to off. 

Files to test can be found here: 
[Uploading HaloCEVR.zip…]()



