### PR TITLE
Disable holsters by default, update README/config

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -761,7 +761,7 @@ void Game::SetupConfigs()
 	c_UIOverlayDistance = config.RegisterFloat("UIOverlayDistance", "Distance in metres in front of the HMD to display the UI", 15.0f);
 	c_UIOverlayScale = config.RegisterFloat("UIOverlayScale", "Width of the UI overlay in metres", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 600);
+	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 800);
 	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay in pixels", 600);
 	// Control settings
 	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -777,56 +777,56 @@ void Game::SetupConfigs()
 	c_DrawMirror = config.RegisterBool("DrawMirror", "Update the desktop window display to show the current game view, rather than leaving it on the splash screen", true);
 	c_MirrorEye = config.RegisterInt("MirrorEye", "Index of the eye to use for the mirror view  (0 = left, 1 = right)", 0);
 	// UI settings
-	c_CrosshairDistance = config.RegisterFloat("CrosshairDistance", "Distance in metres in front of the weapon to display the crosshair", 15.0f);
-	c_MenuOverlayDistance = config.RegisterFloat("MenuOverlayDistance", "Distance in metres in front of the HMD to display the menu", 15.0f);
-	c_UIOverlayDistance = config.RegisterFloat("UIOverlayDistance", "Distance in metres in front of the HMD to display the UI", 15.0f);
-	c_UIOverlayScale = config.RegisterFloat("UIOverlayScale", "Width of the UI overlay in metres", 10.0f);
-	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay in metres", 10.0f);
-	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay in metres", 10.0f);
-	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 800);
-	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay in pixels", 600);
-	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Display a floating crosshair in the world at the location you are aiming", true);
+	c_CrosshairDistance = config.RegisterFloat("CrosshairDistance", "Distance (in metres) in front of the weapon to display the crosshair", 15.0f);
+	c_MenuOverlayDistance = config.RegisterFloat("MenuOverlayDistance", "Distance (in metres) in front of the HMD to display the menu", 15.0f);
+	c_UIOverlayDistance = config.RegisterFloat("UIOverlayDistance", "Distance (in metres) in front of the HMD to display the UI", 15.0f);
+	c_UIOverlayScale = config.RegisterFloat("UIOverlayScale", "Width of the UI overlay (in metres)", 10.0f);
+	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay (in metres)", 10.0f);
+	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay (in metres)", 10.0f);
+	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI overlay, on a scale of 0 to 1", 0.1f);
+	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay (in pixels)", 800);
+	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay (in pixels)", 600);
+	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Displays a floating crosshair in the world where your weapon is aiming", true);
 	// Control settings
-	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);
-	c_SnapTurn = config.RegisterBool("SnapTurn", "The look input will instantly rotate the view by a fixed amount, rather than smoothly rotating", true);
-	c_SnapTurnAmount = config.RegisterFloat("SnapTurnAmount", "Rotation in degrees a single snap turn will rotate the view by", 45.0f);
-	c_SmoothTurnAmount = config.RegisterFloat("SmoothTurnAmount", "Rotation in degrees per second the view will turn at when not using snap turning", 90.0f);
+	c_LeftHanded = config.RegisterBool("LeftHanded", "When enabled, the left hand is the dominant hand. Does not affect bindings - change these in the SteamVR overlay", false);
+	c_SnapTurn = config.RegisterBool("SnapTurn", "When enabled, the look input will instantly rotate the view by a fixed amount, rather than smoothly rotating", true);
+	c_SnapTurnAmount = config.RegisterFloat("SnapTurnAmount", "Rotation (in degrees) a single snap turn will rotate the view by", 45.0f);
+	c_SmoothTurnAmount = config.RegisterFloat("SmoothTurnAmount", "Rotation (in degrees per second) the view will turn at when not using snap turning", 90.0f);
 	c_HandRelativeMovement = config.RegisterInt("HandRelativeMovement", "Movement is relative to hand orientation, rather than head, 0 = off, 1 = left, 2 = right", 0);
-	c_HandRelativeOffsetRotation = config.RegisterFloat("HandRelativeOffsetRotation", "Hand direction rotational offset in degrees used for hand-relative movement", -20.0f);
-	c_HorizontalVehicleTurnAmount = config.RegisterFloat("HorizontalVehicleTurnAmount", "Rotation in degrees per second the view will turn horizontally when in vehicles (<0 to invert)", 90.0f);
-	c_VerticalVehicleTurnAmount = config.RegisterFloat("VerticalVehicleTurnAmount", "Rotation in degrees per second the view will turn vertically when in vehicles (<0 to invert)", 45.0f);
-	c_ToggleGrip = config.RegisterBool("ToggleGrip", "When true releasing two handed weapons requires pressing the grip action again", false);
+	c_HandRelativeOffsetRotation = config.RegisterFloat("HandRelativeOffsetRotation", "Hand direction rotational offset (in degrees). Used for hand-relative movement", -20.0f);
+	c_HorizontalVehicleTurnAmount = config.RegisterFloat("HorizontalVehicleTurnAmount", "Rotation (in degrees per second) the view will turn horizontally when in vehicles (<0 to invert)", 90.0f);
+	c_VerticalVehicleTurnAmount = config.RegisterFloat("VerticalVehicleTurnAmount", "Rotation (in degrees per second) the view will turn vertically when in vehicles (<0 to invert)", 45.0f);
+	c_ToggleGrip = config.RegisterBool("ToggleGrip", "When enabled, releasing two handed weapons will require pressing the grip action again", false);
 	c_TwoHandDistance = config.RegisterFloat("TwoHandDistance", "Maximum distance between both hands where the off hand grip action will enable two handed aiming (<0 for any distance)", 0.8f);
 	c_LeftHandFlashlightDistance = config.RegisterFloat("LeftHandFlashlight", "Bringing the left hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
 	c_RightHandFlashlightDistance = config.RegisterFloat("RightHandFlashlight", "Bringing the right hand within this distance of the head will toggle the flashlight (<0 to disable)", -1.0f);
 	c_LeftHandMeleeSwingSpeed = config.RegisterFloat("LeftHandMeleeSwingSpeed", "Minimum vertical velocity of left hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_RightHandMeleeSwingSpeed = config.RegisterFloat("RightHandMeleeSwingSpeed", "Minimum vertical velocity of right hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
-	c_CrouchHeight = config.RegisterFloat("CrouchHeight", "Minimum height to duck by in metres to automatically trigger the crouch input in game (<0 to disable)", 0.15f);
+	c_CrouchHeight = config.RegisterFloat("CrouchHeight", "Minimum height to duck by (in metres) to automatically trigger the crouch input in game (<0 to disable)", 0.15f);
 	// Hand settings
-	c_ControllerOffset = config.RegisterVector3("ControllerOffset", "Offset from the controller's position used when calculating the in game hand position", Vector3(0.0f, 0.0f, 0.0f));
-	c_ControllerRotation = config.RegisterVector3("ControllerRotation", "Rotation added to the controller when calculating the in game hand rotation", Vector3(0.0f, 0.0f, 0.0f));
+	c_ControllerOffset = config.RegisterVector3("ControllerOffset", "Offset from the controller's position used to calculate the in game hand position", Vector3(0.0f, 0.0f, 0.0f));
+	c_ControllerRotation = config.RegisterVector3("ControllerRotation", "Rotation added to the controller to calculate the in game hand rotation", Vector3(0.0f, 0.0f, 0.0f));
 	c_ScopeRenderScale = config.RegisterFloat("ScopeRenderScale", "Size of the scope render target, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 1.0f);
-	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view in metres", 0.05f);
-	c_ScopeOffsetPistol = config.RegisterVector3("ScopeOffsetPistol", "Offset of the scope view relative to the pistol's location", Vector3(-0.1f, 0.0f, 0.15f));
-	c_ScopeOffsetSniper = config.RegisterVector3("ScopeOffsetSniper", "Offset of the scope view relative to the pistol's location", Vector3(-0.15f, 0.0f, 0.15f));
-	c_ScopeOffsetRocket = config.RegisterVector3("ScopeOffsetRocket", "Offset of the scope view relative to the pistol's location", Vector3(0.1f, 0.2f, 0.1f));
+	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view (in metres)", 0.05f);
+	c_ScopeOffsetPistol = config.RegisterVector3("ScopeOffsetPistol", "Offset of the scope view, relative to the pistol's location", Vector3(-0.1f, 0.0f, 0.15f));
+	c_ScopeOffsetSniper = config.RegisterVector3("ScopeOffsetSniper", "Offset of the scope view, relative to the pistol's location", Vector3(-0.15f, 0.0f, 0.15f));
+	c_ScopeOffsetRocket = config.RegisterVector3("ScopeOffsetRocket", "Offset of the scope view, relative to the pistol's location", Vector3(0.1f, 0.2f, 0.1f));
 	c_WeaponSmoothingAmountNoZoom = config.RegisterFloat("UnzoomedWeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when not zoomed in (0 is disabled, 1 is maximum, recommended around 0-0.2)", 0.0f);
 	c_WeaponSmoothingAmountOneZoom = config.RegisterFloat("Zoom1WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in once, eg zooming on the pistol (0 is disabled, 1 is maximum, recommended around 0.3-0.5)", 0.4f);
 	c_WeaponSmoothingAmountTwoZoom = config.RegisterFloat("Zoom2WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in twice, eg second zoom on sniper (0 is disabled, 1 is maximum, recommended around 0.6-1)", 0.6f);
 	// Weapon holster settings
-	c_EnableWeaponHolsters = config.RegisterBool("EnableWeaponHolsters", "When enabled Weapons can only be switched by using the 'SwitchWeapons' binding while the dominant hand is within distance of a holster", true);
+	c_EnableWeaponHolsters = config.RegisterBool("EnableWeaponHolsters", "When enabled, weapons can only be switched by using the 'SwitchWeapons' binding while the dominant hand is within distance of a holster", false);
 	c_LeftShoulderHolsterActivationDistance = config.RegisterFloat("LeftShoulderHolsterDistance", "The 'size' of the left shoulder holster. This is the distance that the dominant hand needs to be from the holster to change weapons (<0 to disable)", 0.3f);
 	c_LeftShoulderHolsterOffset = config.RegisterVector3("LeftShoulderHolsterOffset", "The (foward, left, up) Offset of the left shoulder holster relative to the headset's location", Vector3(-0.15f, 0.25f, -0.25f));
 	c_RightShoulderHolsterActivationDistance = config.RegisterFloat("RightShoulderHolsterDistance", "The 'size' of the right shoulder holster. This is the distance that the dominant hand needs to be from the holster to change weapons (<0 to disable)", 0.3f);
 	c_RightShoulderHolsterOffset = config.RegisterVector3("RightShoulderHolsterOffset", "The (foward, left, up) Offset of the right shoulder holster relative to the headset's location", Vector3(-0.15f, -0.25f, -0.25f));
 	// Misc settings
-	c_ShowRoomCentre = config.RegisterBool("ShowRoomCentre", "Draw an indicator at your feet to show where the player character is actually positioned", true);
-	c_d3d9Path = config.RegisterString("CustomD3D9Path", "If set first try to load d3d9.dll from the specified path instead of from system32", "");
-	c_TEMPViewportLeft = config.RegisterFloat("TEMP_ViewportLeft", "Some headsets experience warping when turning, as a workaround the viewport scaling has been exposed so users can adjust them until the warping stops", -1.0f);
-	c_TEMPViewportRight = config.RegisterFloat("TEMP_ViewportRight", "Some headsets experience warping when turning, as a workaround the viewport scaling has been exposed so users can adjust them until the warping stops", 1.0f);
-	c_TEMPViewportTop = config.RegisterFloat("TEMP_ViewportTop", "Some headsets experience warping when turning, as a workaround the viewport scaling has been exposed so users can adjust them until the warping stops", -1.0f);
-	c_TEMPViewportBottom = config.RegisterFloat("TEMP_ViewportBottom", "Some headsets experience warping when turning, as a workaround the viewport scaling has been exposed so users can adjust them until the warping stops", 1.0f);
+	c_ShowRoomCentre = config.RegisterBool("ShowRoomCentre", "When enabled, draws an indicator at your feet to show where the player character is actually positioned", true);
+	c_d3d9Path = config.RegisterString("CustomD3D9Path", "If set, will first try to load d3d9.dll from the specified path instead of from system32", "");
+	c_TEMPViewportLeft = config.RegisterFloat("TEMP_ViewportLeft", "Some headsets experience warping when turning. As a workaround, the viewport scaling has been exposed so users can adjust them until the warping stops", -1.0f);
+	c_TEMPViewportRight = config.RegisterFloat("TEMP_ViewportRight", "Some headsets experience warping when turning. As a workaround, the viewport scaling has been exposed so users can adjust them until the warping stops", 1.0f);
+	c_TEMPViewportTop = config.RegisterFloat("TEMP_ViewportTop", "Some headsets experience warping when turning. As a workaround, the viewport scaling has been exposed so users can adjust them until the warping stops", -1.0f);
+	c_TEMPViewportBottom = config.RegisterFloat("TEMP_ViewportBottom", "Some headsets experience warping when turning. As a workaround, the viewport scaling has been exposed so users can adjust them until the warping stops", 1.0f);
 
 	const bool bLoadedConfig = config.LoadFromFile("VR/config.txt");
 	const bool bSavedConfig = config.SaveToFile("VR/config.txt");
@@ -844,7 +844,7 @@ void Game::SetupConfigs()
 	// First run, but couldn't create config file
 	if (!bLoadedConfig && !bSavedConfig)
 	{
-		Logger::err << "Could not create /VR/config.txt.\nHalo may have been installed in Program Files, to generate the config file either run halo.exe as an administrator or reinstall the game in a non-protected folder (e.g. Documents)." << std::endl;
+		Logger::err << "Could not create /VR/config.txt.\nHalo may have been installed in Program Files. To generate the config file, either run halo.exe as an administrator or reinstall the game in a non-protected folder (e.g. Documents)." << std::endl;
 	}
 
 	weaponHandler.localOffset = Vector3(c_ControllerOffset->Value().x, c_ControllerOffset->Value().y, c_ControllerOffset->Value().z);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -784,7 +784,7 @@ void Game::SetupConfigs()
 	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay (in metres)", 10.0f);
 	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay (in metres)", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay (in pixels)", 800);
+	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay (in pixels)", 600);
 	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay (in pixels)", 600);
 	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Displays a floating crosshair in the world where your weapon is aiming", true);
 	// Control settings

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 
 [Mod Download here](../../releases)
 
-**This mod is not compatible with _The Master Chief Collection_**
+**This mod is not compatible with _The Master Chief Collection_.**
 
 ## Features
 * 6DoF Synced Stereo view (i.e. VR camera without any AER/3D screen nonsense)
@@ -28,101 +28,113 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 
 ## Known issues
 * Game sometimes isn't the focused window on launch and inputs/sounds may break when the game is unfocused
-* First stage of the tutorial ("look around") doesn't detect headset movement, wiggle the mouse and you should get passed it
+* First stage of the tutorial ("look around") doesn't detect headset movement (wiggle the mouse and you should get past it)
 * Camera behaves weirdly briefly when entering/exiting vehicles
-* Reloading a checkpoint made while in a vehicle can mess with the camera position, get out and in again to fix it
+* Reloading a checkpoint made while in a vehicle can mess with the camera position (get out and in again to fix it)
 * Melee and interact use head aiming rather than controller aiming
 * Crosshair only lights up red when looking at an enemy, not when pointing a gun at one
 * On screen button prompts display keyboard bindings rather than VR bindings
-* If the game is installed in program files the mod config file (and log file) won't generate unless the game is run as administrator
+* If Halo is installed in Program Files, the mod's config file (and log file) won't generate unless Halo is run as administrator
 * Occasional stutters can cause motion smoothing to kick in, which is very jarring in vehicles
 * Some people report a minor distortion or warping effect when tilting their head side to side.
 
 ## Installation
-0. Install _Halo: Combat Evolved for PC_ (not Custom Edition) using an original installation CD + product key.  IMPORTANT: Install in a directory OTHER THAN Program Files (example: C:\HaloVRMod\Halo). Installing in Program Files potentailly causes numerous permissions-related issues.
-1. Install the 1.10 patch for PC (not Custom Edition)
-2. (Optional) Install [chimera](https://github.com/SnowyMouse/chimera) (fixes a few bugs/issues such as entities moving at 30fps).  Grab the RELEASE files from [releases](https://github.com/SnowyMouse/chimera/releases/download/1.0.0r1021/chimera-1.0.0r1021.10144368.7z).  Copy chimera.ini, strings.dll, and the fonts folder from the chimera zip after unzipping and place into your halo game folder in the same location as halo.exe.
-3. If using chimera: open chimera.ini, locate the "Font Override Settings" section, and change enabled=1 to enabled=0 (failing to do this will break many UI elements in VR)
-4. Download the latest version of this mod from the [releases page](../../releases)
-5. Extract HaloCEVR.zip and place the files in the same directory as the halo executable (You should see a VR folder, openvr_api.dll and d3d9.dll if done correctly - if you do not see these files your antivirus may be interfering)
-6. Launch the game once to generate a config.txt file in the VR directory
-7. If setting LeftHanded=true in the config, consider selecting the left handed controller bindings in the game's SteamVR controller bindings page
+0. Install _Halo: Combat Evolved for PC_ (not Custom Edition) using your original installation media and product key.  
+  > [!IMPORTANT] 
+  > Installing in Program Files causes numerous permissions-related issues. You should install to a directory outside Program Files. <br> (i.e. `C:\HaloVRMod\Halo`).
+
+1. Install the 1.10 patch for Halo PC (not Custom Edition)
+2. Install [Chimera](https://github.com/SnowyMouse/chimera), which fixes issues like entities moving at 30 FPS. (Optional, but recommended)
+  > Grab the RELEASE files from releases [(direct link)](https://github.com/SnowyMouse/chimera/releases/download/1.0.0r1021/chimera-1.0.0r1021.10144368.7z).
+  > Copy chimera.ini, strings.dll, and the fonts folder from the Chimera zip after unzipping, and place into your Halo game folder in the same location as halo.exe.
+3. If using Chimera, disable the font override. (Failing to do this will break many UI elements in VR.)
+  > Open chimera.ini, and locate the "Font override settings" section. Where it says `; Enable overriding Chimera's fonts` change `enabled=1` to `enabled=0`.
+4. Download the latest version of this mod from the [releases page](../../releases).
+  > Make sure you download HaloCEVR.zip, not the source code.
+5. Extract HaloCEVR.zip, and place the files in the same directory as the halo.exe executable.
+  > You should see a VR folder, openvr_api.dll, and d3d9.dll if everything is correct. Copy these files. If you do not see these files, your antivirus may be interfering. 
+6. Launch the game once to generate a config.txt file in the VR directory.
+7. If setting LeftHanded=true in the config, consider selecting the left handed controller bindings in the game's SteamVR controller bindings page for a better experience. 
 
 ## Uninstalling
-1. Go play the MCC version instead
-2. Delete/rename the d3d9.dll you placed in the same directory as the halo executable (this contains all of the mod code and is only pretending to be d3d9 to trick halo into loading it).  For example, you could rename it to d3d9-backup.dll.
+0. Just play the MCC version instead!
+1. Delete or rename the d3d9.dll next to halo.exe you placed in the same directory as the Halo executable. For example, you could rename it to d3d9-backup.dll. (This contains all of the mod code, and is only pretending to be D3D9 to trick Halo into loading it.)
 
 ## FAQ
-### Why the gearbox port and not MCC?
+### Why the Gearbox port and not MCC?
 Short answer: skill issue.
 
-Long answer: This mod my first time attempting to reverse engineer and mod a close sourced game engine requiring learning how to decompile, analyse and patch x86 assembly.
+Long answer: This mod's my first time attempting to reverse engineer and mod a closed source game engine requiring learning how to decompile, analyse and patch x86 assembly.
 As you may guess, this is hard. By focusing on an older title I have a simpler project to work with as I do not have an additional 2 decades worth of updates and advances in technology to worry about.
 
 (For example, no dual classic/aniversary graphics, no MCC launcher application separate to the halo1 game code, DirectX9 rather than DirectX11, x64, simpler code layout with few virtual functions to follow (which I struggled to analyse in Ghidra).
 ### Where do I even get a CD copy in \<current year\>? Can I use a cracked version?
-No.
+No, you can't use a cracked version.
 
-This mod is intended to only be used with legitimate copies of Halo: Combat Evolved with the official 1.10 patch. Fortunately the product keys aren't single use, so if you can find a second hand copy (or a friend willing to lend the copy they happened to archive 20 years ago) you can use that without worrying about the key being invalid. 
+This mod is intended to only be used with legitimate copies of Halo: Combat Evolved with the official 1.10 patch. Fortunately, the product keys aren't single use. If you can find a second hand copy, or a friend willing to lend the copy they happened to archive 20 years ago, you can use that without worrying about the key being invalid. 
 ### Does multiplayer work?
-This mod was designed for singleplayer, it is untested in multiplayer and as such some features, such as weapon aiming, may not function or only work for the host.
+This mod was designed for singleplayer. It is untested in multiplayer and as such some features, such as weapon aiming, may not function or only work for the host.
 
-Also it does not work in Co-op because this version of the game does not have that mode.
+Also, the original PC version of Halo doesn't have a co-op mode, so there is no co-op support either. 
 ### Does this work with Custom Edition?
 No.
-### Does this work with MCC Edition?
-No.
+### Does this work with the MCC Edition?
+No. See above.
 ### Does this work with SPV3?
-No, SPV3 depends on Halo Custom Edition which is presently incompatible.
+No. SPV3 depends on Halo Custom Edition, which is presently incompatible.
 ### Does this work with other mods?
-Maybe, if they only need the PC edition and do not change the underlying structure of the game in a way that interferes with the VR mod. The focus of this mod is making sure the base game works in VR.
-### Help! The game launches in VR but I cannot interact with the main menu! My buttons do not work!
-Make sure the game window on your desktop is in focus (switch back to desktop view and click on the window).  If that does not work make sure you're actually using a SteamVR runtime.
-### Help! I've tried EVERYTHING to the letter and something is still wrong.
-A very few users have reported reinstalling SteamVR helps.  Not sure why.  Triple check your anti-virus is not blocking anything.  If you still have trouble join the flat2VR discord, find the hvr-join channel, and post about your issue, including as many details as possible about your system and what you have done to install.  The community may be able to help you.
-### Help! I get to the tutorial and am stuck when I am supposed to look around.
-Either play through this initial part of the game in flat screen, or walk over to your computer and wiggle the mouse and it should get you past this point.
-### Which config.txt file do I use to make changes to VR settings?  What if I am making changes but don't see changes in game?
-The one found in the "VR" folder after install and after you run the game once in VR. If you are not seeing changes you make take effect in game, then chances are you disregarded the instruction not to install in Program Files.  You can try running in administrator mode to make the edits but safer to just install Halo and the mod in a new location.
+Maybe. The focus of this mod is making sure the base game works in VR. If the mod only needs the PC edition, and do not change the underlying structure of the game in a way that interferes with the VR mod, it might work. 
+### Help! The game launches in VR, but I cannot interact with the main menu! My buttons do not work!
+Make sure the game window on your desktop is in focus (switch back to desktop view and click on the window).  If that does not work, make sure you're actually using a SteamVR runtime.
+### Help! I've followed EVERYTHING to the letter and something is still wrong.
+A very few users have reported reinstalling SteamVR helps.  Not sure why.  Triple check your anti-virus is not blocking anything.  If you still have trouble join the Flat2VR discord, find the hvr-join channel, and post about your issue, including as many details as possible about your system and what you have done to install.  The community may be able to help you.
+### Help! I get to the tutorial and I'm stuck when I am supposed to look around.
+Walk over to your computer and wiggle the mouse, or play through this initial part of the game in flat screen. 
+### Which config.txt file do I use to make changes to VR settings? 
+The one found in the "VR" folder, which is created after install and after you've run the game once in VR. 
+### I'm changing the config.txt, but the changes don't take effect in-game?
+If you aren't seeing changes you make take effect in game, chances are you disregarded the instruction not to install in Program Files. Try running Halo in Administrator mode to make the edits, but it's safer to just install Halo and the mod in a new location.
 ### How do I turn on the flashlight?
-By default tapping your head with your left hand will toggle the flashlight, you can adjust the radius this triggers at and which hand to use in config.txt. Alternatively there is an optional binding you can configure in SteamVR's controller bindings page to toggle it directly.
-### How do I melee/can melee be bound to a button on my controller?
-By default swinging either controller vertically with enough speed will trigger a melee attack wherever you are looking. If preferred there is a controller binding that is unset by default you can configure instead.
-
-### How do I switch weapons?
-By default, you can switch weapons using the shoulder weapon holsters. To do this, hover your dominant hand over a shoulder and press the Switch Weapon controller binding (can be configured in SteamVR's bindings).
-If you prefer, you can adjust the settings for the weapon holsters or disable them in config.txt to switch weapons using only the controller binding.
-
+By default, tapping your head with your left hand will toggle the flashlight. You can adjust the radius this triggers at, and which hand to use, in config.txt. Alternatively, there is an optional binding you can configure in SteamVR's controller bindings page to toggle the flashlight directly.
+### How do I melee? / Can melee be bound to a button on my controller?
+By default, swinging either controller vertically with enough speed will trigger a melee attack where you are looking. If you prefer a button, there is a controller binding that is unset by default which you can configure in the SteamVR bindings.
+### How do I switch weapons with the holsters enabled?
+Hover your dominant hand over a shoulder and press the Switch Weapon controller binding. (can be configured in SteamVR's bindings)
+If you prefer, you can adjust the settings for the weapon holsters in config.txt.
 ### How do I activate smooth turning?
-Go to the VR config.txt file and change SnapTurn = false.  You can also adjust turning speed with SmoothTurnAmount.
+Open the VR config.txt file, and change "SnapTurn" to false - `SnapTurn = false`.  You can also adjust the turning speed with SmoothTurnAmount.
 ### How do I activate hand-directed movement?
-By default movement is in the direction the player's head is facing. If you would like to use hand-directed movement, open the VR config.txt file, and find these lines:
-```//[Int] Movement is relative to hand orientation, rather than head, 0 = off, 1 = left, 2 = right (Default Value: 0)
+By default, movement is in the direction the player's head is facing. If you would like to use hand-directed movement, open the VR config.txt file, and find these lines:
+```
+//[Int] Movement is relative to hand orientation, rather than head, 0 = off, 1 = left, 2 = right (Default Value: 0)
 HandRelativeMovement = 0
 
-//[Float] Hand direction rotational offset in degrees used for hand-relative movement (Default Value: -20)
+//[Float] Hand direction rotational offset (in degrees). Used for hand-relative movement (Default Value: -20)
 HandRelativeOffsetRotation = -20
 ```
-Change HandRelativeMovement to 1 for movement to follow your left hand direction or 2 for movement to follow your right hand direction.
+Change HandRelativeMovement to 1 for movement to follow your left hand direction, or 2 for movement to follow your right hand direction.
 ### How do I turn the crosshair off?
-Open the VR config.txt file and change "ShowCrosshair" to false - "ShowCrosshair=false"
-### Things feel constantly jittery in vehicles
-Halo internally runs a lower tick rate (I believe it is 30fps) and only interpolates the player camera, this makes things feel jittery when driving vehicles. To fix this install [chimera](https://github.com/SnowyMouse/chimera), as they have fixed this issue along with many others. If you still experience intermittent stuttering on vehicles it may be due to the motion smoothing kicking in and locking the frame rate to 45 for a few seconds, you may experience smoother results by disabling it. 
+Open the VR config.txt file and change "ShowCrosshair" to false - `ShowCrosshair = false`
+### Things feel constantly jittery in vehicles...
+Halo internally runs a lower tick rate (i.e. 30 FPS) and only visually interpolates the first-person player camera. This makes things feel jittery when driving vehicles, as they only move at the lower tick rate. 
+To fix this, install [Chimera](https://github.com/SnowyMouse/chimera), as they have fixed this issue along with many others. If you still experience intermittent stuttering on vehicles, it may be due to the motion smoothing kicking in and locking the frame rate to 45 for a few seconds. You may experience smoother results by disabling it.
 ### Does this mod support OpenXR?
-No, this mod is exclusively for SteamVR since it is the only runtime to support 32bit applications to my knowledge.  This means you need to choose the SteamVR runtime in your VR software if available. For example, with Oculus Link you need to make sure you have SteamVR running, or with WMR you need to use the SteamVR runtime.
-### Help the camera is too high/too low (or crouch seems to be stuck on)
+No. This mod is exclusively for SteamVR, since it is the only runtime to support 32-bit applications to my knowledge.  This means you need to choose the SteamVR runtime in your VR software, if available. For example, with Oculus Link, you need to make sure you have SteamVR running, or with WMR you need to use the SteamVR runtime.
+### Help, the camera is too high/too low (or crouch seems to be stuck on)!
 Stand up straight (or sit up if playing seated) and hold down the menu button for 3 seconds to recentre the camera to your current physical position.
 ### How do I crouch?
-By default you crouch in real life. If you do not prefer that, change the option in the config.txt file in the VR folder, specifically set CrouchHeight = -1.0 and bind a button to crouch in the SteamVR Input menu.
-### I wish (insert action) was bound to a different key
-Use SteamVR input settings to change your bindings to whatever you want. You can also search for other peoples' bindings for your controller in the bindings menu.  You can learn how to use SteamVR input by watching this video by HoriZon, who also has bindings available for Quest controllers: https://www.youtube.com/watch?v=rdlCu7IjbGI.  It's useful in a bunch of games!
-### Textures seem to pop in too much.  Any fix?
-Try using chimera (highly recommended anyway) and create a file called chimera_preferences.txt in your Halo directory.  In that text file, insert the following lines:
+By default, physically crouching will allow you to crouch. You can adjust this behaviour in config.txt. 
+Alternatively, press Down on the right controller (the one you use to turn) - your view won't change, but you will be able to fit through small spaces.
+### I wish (insert action) was bound to a different key...
+Use SteamVR input settings to change your bindings to whatever you want! You can also search for other peoples' bindings for your controller in the bindings menu.  You can learn how to use SteamVR input by watching this video by HoriZon, who also has custom bindings available for Quest controllers: https://www.youtube.com/watch?v=rdlCu7IjbGI.  It's useful in a bunch of games!
+### Things seem to pop in and out a lot...
+Chimera lowers the LOD level to fix some visual bugs in the original game with high resolutions. Fortunately, these bugs aren't a huge problem in VR, so we can improve the LOD by creating a Chimera preferences file.  
+
+Create a file called chimera_preferences.txt in your Halo directory.  In that text file, insert the following lines:
 ```
 chimera_model_detail 8
-chimera_lod 1
 ```
-Then in your chimera.ini file, find the line that starts with ;exec= and change it to:
+Then in your chimera.ini file, find the line that starts with `;exec=` and change it to:
 ```
 exec=path\to\your\chimera_preferences.txt
 ```
@@ -130,16 +142,13 @@ Example:
 ```
 exec=C:\HaloVRMod\Halo\chimera_preferences.txt
 ```
-Note that deleting the semicolon is what makes this line active.  It's telling chimera to load the text commands you wrote that control the level of detail. If others share chimera commands in the future you can place them here.
-You can test that the commands are being executed by changing the name of the VR mod dll file, d3d9.dll, to something else temporarily and booting the game up in flat screen.  The commands will flash on the screen if this step worked.
-#### How can I make sounds even more immersive?
-Check out DSOAL for 3D sound ingame: https://github.com/ThreeDeeJay/dsoal/releases/tag/0.9.6, specific download zip link: https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
--Extract to a location on your computer. Inside the zip, find the Win32 folder, open it, and copy and paste all Win32 files into your Halo folder
--One of the files will be called alsoft.ini which is a configuration file for DSOAL.
-
-Path: Halo>alsoft.ini
-
-Copy and Paste into alsoft.ini:
+Note that deleting the semicolon is what makes this line take effect. It's telling Chimera to load the text commands you wrote. If other useful Chimera commands are shared by the community in future, you can place them in that file too.
+You can check that the commands are being executed by temporarily removing the VR mod (i.e. by changing the name of the VR mod file, d3d9.dll, to something else) and booting the game up in flat screen mode. The text commands will flash on the screen if this step worked.
+### Can I make the game sound even more immersive?
+Using [DSOAL](https://github.com/ThreeDeeJay/dsoal/releases/tag/0.9.6), you can have full directional 3D sound in-game.
+1. Download it from here: [DSOAL+HRTF.zip](https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip)
+2. Extract to a location on your computer or open the zip file. Inside the zip, find the Win32 folder. Open it, and you should see `dsound.dll` and some other files. Copy and paste those files into your Halo folder next to the halo.exe. 
+3. One of the files will be called `alsoft.ini`, which is a configuration file for DSOAL. For best results, use these community-provided settings for DSOAL. Copy and paste the following into alsoft.ini:
 ```
  [general]
 channels=stereo
@@ -169,4 +178,4 @@ This should be everything that needs to be done inside of the HaloCEVR project, 
 4. Build the libMinHook project, the result of which should be a libMinHook.x86.lib file.
 5. Replace the file libMinHook.x86.lib in the HaloCEVR folder found at HaloCEVR-master\ThirdParty\MinHook\lib with this newly compiled libMinHook.x86.lib file
 
-You should now be able to build successfully, this will generate a d3d9.dll file, using the "makerelease" bat file we can create a zip containing the d3d9.dll and the VR folder. You will need to add openvr_api.dll yourself, either by adding to the release folder so the bat file can pickup copy and zip it, or by adding it directly into your halo CE installation directory.
+You should now be able to build successfully. This will generate a d3d9.dll file, and using the "makerelease" bat file we can create a zip containing the d3d9.dll and the VR folder. You will need to add openvr_api.dll yourself, either by adding to the release folder so the bat file can pickup a copy and zip it, or by adding it directly into your Halo CE installation directory.


### PR DESCRIPTION
This PR contains two sets of changes
- Tweaks to Game.cpp and README.md to make things a bit easier to read
- Disabled weapon holstering by default in Game.cpp

The weapon holstering changes are mostly because it isn't obvious in-game that it's on, so best to prevent people from filing issues about changing weapons not working.
Changes to Game.cpp were to make things a bit more readable by putting "in meters" and etc. in brackets.
Changes to README.md were to clean up some grammatical errors and make instructions for things like install location and Chimera settings more spaced out so they're harder to miss. 