### PR TITLE
Readme update, dedicated section for installing enhancements and Halo Refined

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,73 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 1. Go play the MCC version instead
 2. Delete/rename the d3d9.dll you placed in the same directory as the halo executable (this contains all of the mod code and is only pretending to be d3d9 to trick halo into loading it).  For example, you could rename it to d3d9-backup.dll.
 
+## Graphical and Audio Enhancements, Restoration
+### dsoal 
+
+Dsoal allows you to turn on hardware acceleration and EAX in Halo without said hardware to enjoy environmental sound effects like reverb and HRTF(head-related transfer function), providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended even for low fidelity audio such as on Quest. (Notice: Doesn't currently work on first-person sounds)
+
+1) Download and extract https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
+2) Open the \Win32\ folder
+3) Copy & paste all files (alsoft.ini, dsoal-aldrv.dll, dsound.dll) in your \Halo\halo.exe folder.
+4) Edit and paste these settings into alsoft.ini:
+```
+ [general]
+channels=stereo
+frequency=48000
+stereo-mode=headphones
+cf_level=0
+sources=512
+sample-type=float32
+hrtf=true
+period_size=960
+hrtf-mode = full
+
+[reverb]
+boost=-6
+```
+### chimera
+
+Chimera passively increases animation framerate, corrects some fog, boosts polygon limit, object limit, and draw distance. Highly recommended for comfort and bug fixes alone.
+
+See installation instructions above. If you installed chimera, you can execute commands to reduce pop-in and low detail models (lods), turn on anisotrophic filtering for sharper textures on world geometry, and turn on reverberation for first person sounds (requires dsoal). These are not turned on by default. There are several ways to do this. Please read about all 3 methods before proceeding.
+
+To launch the game in flat mode and use the console with the tilde ~ key, you can temporarily rename d3d9.dll to d3d9aa.dll. However executed console commands are saved and read from/to a text file, which you can navigate to and edit directly instead.
+
+Go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands.
+```
+chimera_model_detail 8
+chimera_af 1
+chimera_fp_reverb 1
+```
+If you want these preferences to be portable and travel with your Halo installation:
+
+1) Create a new text file named chimera_preferences.txt in the \Halo\ folder along side chimera.ini
+2) edit \Halo\chimera.ini
+3) Do not paste the commands into chimera.ini, some of them will not work
+5) chimera.ini comments(disables) lines with a semi-colon ```;```. Find ```exec=``` and remove any semi-colon on that line, such as ```;exec=```
+6) set the value to ```exec=./chimera_preferences.txt```
+7) paste the commands listed above into chimera_preferences.txt
+
+### Halo Refined
+
+When Halo was ported to PC in 2003, many graphical effects present in the original Xbox version were broken and outdated assets were accidentally used. Halo Refined is a community project that fixes many issues such as invisible bumpmapping, missing specular, broken transparency effects, etc and provides some faithful high resolution assets by replacing Halo's map files.
+
+Halo Refined is poorly tested with HaloCEVR but seems to work, recommended for experimental use. Please keep back ups of your original .map files before installing. If you are having any issues with HaloCEVR while using Refined's maps, restore the original files and retest before reporting your issue.
+
+Recent versions require chimera. Refined is designed with dgVoodoo2 and CEnshine in mind to fix even more effects, but these are tools and modifications can't be used with HaloCEVR. CEnshine is for Custom Edition only which HaloCEVR does not currently support.
+
+1) Download and extract the latest distribution for Retail, not Custom Edition
+2) Backup all files in \Halo\maps\
+3) Replace files in \Halo\maps\
+4) (Optional) Read \Halo\maps\info.txt
+
+Download, updated as of the time of writing:
+https://www.proxeninc.net/Halo/Refined/
+
+Mirror, outdated as of the time of writing:
+http://vaporeon.io/hosted/halo/refined/
+
+
 ## FAQ
 ### Why the gearbox port and not MCC?
 Short answer: skill issue.
@@ -116,44 +183,6 @@ Stand up straight (or sit up if playing seated) and hold down the menu button fo
 By default you crouch in real life. If you do not prefer that, change the option in the config.txt file in the VR folder, specifically set CrouchHeight = -1.0 and bind a button to crouch in the SteamVR Input menu.
 ### I wish (insert action) was bound to a different key
 Use SteamVR input settings to change your bindings to whatever you want. You can also search for other peoples' bindings for your controller in the bindings menu.  You can learn how to use SteamVR input by watching this video by HoriZon, who also has bindings available for Quest controllers: https://www.youtube.com/watch?v=rdlCu7IjbGI.  It's useful in a bunch of games!
-### Textures seem to pop in too much.  Any fix?
-Try using chimera (highly recommended anyway) and create a file called chimera_preferences.txt in your Halo directory.  In that text file, insert the following lines:
-```
-chimera_model_detail 8
-chimera_lod 1
-```
-Then in your chimera.ini file, find the line that starts with ;exec= and change it to:
-```
-exec=path\to\your\chimera_preferences.txt
-```
-Example:
-```
-exec=C:\HaloVRMod\Halo\chimera_preferences.txt
-```
-Note that deleting the semicolon is what makes this line active.  It's telling chimera to load the text commands you wrote that control the level of detail. If others share chimera commands in the future you can place them here.
-You can test that the commands are being executed by changing the name of the VR mod dll file, d3d9.dll, to something else temporarily and booting the game up in flat screen.  The commands will flash on the screen if this step worked.
-#### How can I make sounds even more immersive?
-Check out DSOAL for 3D sound ingame: https://github.com/ThreeDeeJay/dsoal/releases/tag/0.9.6, specific download zip link: https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
--Extract to a location on your computer. Inside the zip, find the Win32 folder, open it, and copy and paste all Win32 files into your Halo folder
--One of the files will be called alsoft.ini which is a configuration file for DSOAL.
-
-Path: Halo>alsoft.ini
-
-Copy and Paste into alsoft.ini:
-```
- [general]
-channels=stereo
-frequency=48000
-stereo-mode=headphones
-cf_level=0
-sources=512
-sample-type=float32
-hrtf=true
-period_size=960
-
-[reverb]
-boost=-6
-```
 ### I know C++ coding or will learn to help develop the mod.  How do I help?
 Thank you! See compiling source directions below and submit a Pull Request on Github explaining the changes you have made and impact on other files.  Be sure to thoroughly test any changes before submitting them. After others and I test the changes, they may be incorporated into the mod release.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Chimera passively increases animation framerate, corrects some fog, boosts polyg
 
 See installation instructions above. If you installed chimera, you can execute commands to reduce pop-in and low detail models (lods), turn on anisotrophic filtering for sharper textures on world geometry, and turn on reverberation for first person sounds (requires dsoal). These are not turned on by default. There are several ways to do this. Please read about all 3 methods before proceeding.
 
-To launch the game in flat mode and use the console with the tilde ~ key, you can temporarily rename d3d9.dll to d3d9aa.dll. However executed console commands are saved and read from/to a text file, which you can navigate to and edit directly instead.
+To launch the game in flat mode and use the console with the tilde ~ key, you can disable the VR mod by temporarily renaming d3d9.dll to something like d3d9aa.dll. However executed console commands are saved and read from/to a text file, which you can navigate to and edit directly instead.
 
 Go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands.
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Note: Chimera is required for reverb on first person sounds. First person sounds
 2) Open the DSOAL+HRTF\Win32\ folder.
 3) Copy & paste all files from Win32\ (alsoft.ini, dsoal-aldrv.dll, dsound.dll) into your Halo\ install folder where halo.exe is located.
 5) Edit alsoft.ini and copy & paste the settings shown below:
-6) Launch Halo and go to Settings >> Audio Setup. Make sure Hardware Acceleration is set to Yes and Environmental Sound to EAX.
+6) ```hrtf-mode = full``` may or may not be CPU intensive, remove if you experience new performance issues.
+7) Launch Halo and go to Settings >> Audio Setup. Make sure Hardware Acceleration is set to Yes and Environmental Sound to EAX.
+
 ```
 [general]
 channels=stereo

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ See installation instructions above. If you installed chimera, there is an enhan
 
 * You can bring up the in-game console with tilde ~ key, but it helps to disable the VR mod by temporarily by renaming d3d9.dll to something like d3d9aa.dll so you can see the console. 
 
-* Executed console commands are saved and read from a text file. You can create this file yourself:
+* Or, executed console commands are saved and read from a text file. You can create this file yourself:
 1) Navigate to (Your User Folder)\Documents\My Games\Halo\chimera\ and create a text file named preferences.txt
 2) Edit your preferences.txt and add ```chimera_model_detail 8```
 
-* If you want this command and other preferences to be portable and travel with your Halo installation:
+* Or, If you want this command and other preferences to be portable and travel with your Halo installation:
 
 1) Create a new text file named chimera_preferences.txt in the Halo\ folder alongside chimera.ini
 2) Edit Halo\chimera.ini

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 1. Go play the MCC version instead
 2. Delete/rename the d3d9.dll you placed in the same directory as the halo executable (this contains all of the mod code and is only pretending to be d3d9 to trick halo into loading it).  For example, you could rename it to d3d9-backup.dll.
 
-## Graphical and Audio Enhancements, Restoration
+## Installing Graphical and Audio Enhancements
 ### dsoal 
 
 Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to use environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended, you do not need high-fidelity headphones to enjoy this.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Note: Chimera is required for reverb on first person sounds. HRTF does not work 
 1) Download and extract from https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
 2) Open the DSOAL+HRTF\Win32\ folder.
 3) Copy & paste all files from Win32\ (alsoft.ini, dsoal-aldrv.dll, dsound.dll) into your Halo\ install folder where halo.exe is located.
-4) Edit alsoft.ini and copy & paste these settings:
+5) Edit alsoft.ini and copy & paste the settings shown below:
+6) Launch Halo and go to Settings >> Audio Setup. Make sure Hardware Acceleration is set to Yes and Environmental Sound to EAX.
 ```
 [general]
 channels=stereo

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 Dsoal allows you to turn on hardware acceleration and EAX in Halo without said hardware to enjoy environmental sound effects like reverb and HRTF(head-related transfer function), providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended even for low fidelity audio such as on Quest. (Notice: Doesn't currently work on first-person sounds)
 
 1) Download and extract https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
-2) Open the \Win32\ folder
-3) Copy & paste all files (alsoft.ini, dsoal-aldrv.dll, dsound.dll) in your \Halo\halo.exe folder.
-4) Edit and paste these settings into alsoft.ini:
+2) Open the \DSOAL+HRTF\Win32\ folder
+3) Copy & paste all files from \Win32\ (alsoft.ini, dsoal-aldrv.dll, dsound.dll) into your \Halo\ install folder where halo.exe is located.
+4) Edit alsoft.ini and copy & paste these settings:
 ```
  [general]
 channels=stereo
@@ -84,7 +84,7 @@ See installation instructions above. If you installed chimera, you can execute c
 
 To launch the game in flat mode and use the console with the tilde ~ key, you can disable the VR mod by temporarily renaming d3d9.dll to something like d3d9aa.dll. However executed console commands are saved and read from/to a text file, which you can navigate to and edit directly instead.
 
-Go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands.
+Go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands:
 ```
 chimera_model_detail 8
 chimera_af 1

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 ## Installing Graphical and Audio Enhancements
 ### dsoal 
 
-Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to use environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended, you do not need high-fidelity headphones to enjoy this.
+Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to use environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended, and you do not need high-fidelity headphones to enjoy this.
 
 Note: Chimera is required for reverb on first person sounds. First person sounds have no stereo/HRTF/location effects.
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 ## Graphical and Audio Enhancements, Restoration
 ### dsoal 
 
-Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to enjoy environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended for even low fidelity headphones such as on Quest. 
+Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to use environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended, you do not need high-fidelity headphones to enjoy this.
 
-Note: Chimera is required for reverb on first person sounds. HRTF does not work on first person sounds.
+Note: Chimera is required for reverb on first person sounds. First person sounds have no stereo/HRTF/location effects.
 
 1) Download and extract from https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
 2) Open the DSOAL+HRTF\Win32\ folder.
@@ -81,39 +81,38 @@ boost=-6
 ```
 ### chimera
 
-Chimera passively increases animation framerate, corrects some fog, boosts polygon limit, object limit, and draw distance, but is highly recommended for bug fixes and QOL changes alone.
+Chimera increases animation framerate, corrects fog, enables anisotropic filtering, enables reverb for first person sounds (requires dsoal), and boosts polygon count, object limit, and draw distance. But is highly recommended for bug fixes and QOL changes alone.
 
-See installation instructions above. If you installed chimera, you can execute console commands to reduce pop-in and low detail models (lods), turn on anisotrophic filtering for sharper textures on world geometry, and turn on reverberation for first person sounds (requires dsoal). These are not turned on by default. There are several ways to do this. Please read about all 3 methods before proceeding.
+See installation instructions above. If you installed chimera, there is an enhancement not enabled by default. You can execute a console command ```chimera_model_detail 8``` to reduce pop-in and low detail models (lods). There are several ways to do this. 
 
-* To launch the game in flat mode and use the console with the tilde ~ key, you can disable the VR mod by temporarily renaming d3d9.dll to something like d3d9aa.dll. 
+* You can bring up the in-game console with tilde ~ key, but it helps to disable the VR mod by temporarily by renaming d3d9.dll to something like d3d9aa.dll so you can see the console. 
 
-* However, executed console commands are saved and read from a text file, it might be easier to edit this file directly instead. After running Halo once with chimera installed, close Halo and go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands:
-```
-chimera_model_detail 8
-chimera_af 1
-chimera_fp_reverb 1
-```
-* If you want these preferences to be portable and travel with your Halo installation:
+* Executed console commands are saved and read from a text file. You can create this file yourself:
+1) Navigate to (Your User Folder)\Documents\My Games\Halo\chimera\ and create a text file named preferences.txt
+2) Edit your preferences.txt and add ```chimera_model_detail 8```
+
+* If you want this command and other preferences to be portable and travel with your Halo installation:
 
 1) Create a new text file named chimera_preferences.txt in the Halo\ folder alongside chimera.ini
-2) edit Halo\chimera.ini
-3) Do not paste the commands into chimera.ini, some of them will not work.
-5) chimera.ini comments(disables) lines with a semi-colon ```;```. Find ```exec=``` and remove any semi-colon on that line, such as ```;exec=```
-6) set the value to ```exec=./chimera_preferences.txt```
-7) paste the commands listed above into chimera_preferences.txt
+2) Edit Halo\chimera.ini
+3) Adding ```chimera_model_detail 8``` into chimera.ini will not work.
+4) chimera.ini disables lines with a semi-colon ```;```
+5) Find ```exec=``` and remove any semi-colon on that line, such as ```;exec=```.
+6) Set the value to ```exec=./chimera_preferences.txt```
+7) Add ```chimera_model_detail 8``` into chimera_preferences.txt
 
 ### Halo Refined
 
 A Community project that restores many graphical effects present in the original Xbox version by replacing Halo's map files. Fixes issues such as invisible bumpmapping, missing specular, broken transparency effects, etc. Also provides some high res asset replacements, most notably an HD HUD. 
 
-Halo Refined is poorly tested with HaloCEVR but seems to work, recommended for experimental use. Please keep back ups of your original .map files before installing. If you are having any issues with HaloCEVR while using Refined's maps, restore the original files and retest before reporting your issue.
+Halo Refined is poorly tested with HaloCEVR but seems to work, recommended for experimental use. Please keep backups of your original .map files before installing. If you are having any issues with HaloCEVR while using Refined's maps, restore the original files and retest before reporting your issue.
 
 Recent versions require chimera. Refined is designed with dgVoodoo2 and CEnshine in mind to fix even more effects, but these are tools and modifications can't be used with HaloCEVR. 
 
 1) Download and extract the latest distribution for Retail, not Custom Edition
 2) Backup all files in Halo\maps\ by copying them to a different location
 3) Replace files in Halo\maps\
-4) (Optional) Read Halo\maps\info.txt
+4) (Optional) Read Halo\maps\info.txt for project information
 
 Download, updated as of the time of writing:
 https://www.proxeninc.net/Halo/Refined/

--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 ## Graphical and Audio Enhancements, Restoration
 ### dsoal 
 
-Dsoal allows you to turn on hardware acceleration and EAX in Halo without said hardware to enjoy environmental sound effects like reverb and HRTF(head-related transfer function), providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended even for low fidelity audio such as on Quest. (Notice: Doesn't currently work on first-person sounds)
+Dsoal allows you to turn on hardware acceleration and EAX in Halo without requisite hardware to enjoy environmental sound effects like reverb and HRTF, providing realistic, locatable 3D sound with high accuracy for virtual reality. Highly recommended for even low fidelity headphones such as on Quest. 
 
-1) Download and extract https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
-2) Open the \DSOAL+HRTF\Win32\ folder
-3) Copy & paste all files from \Win32\ (alsoft.ini, dsoal-aldrv.dll, dsound.dll) into your \Halo\ install folder where halo.exe is located.
+Note: Chimera is required for reverb on first person sounds. HRTF does not work on first person sounds.
+
+1) Download and extract from https://github.com/ThreeDeeJay/dsoal/releases/download/0.9.6/DSOAL+HRTF.zip 
+2) Open the DSOAL+HRTF\Win32\ folder.
+3) Copy & paste all files from Win32\ (alsoft.ini, dsoal-aldrv.dll, dsound.dll) into your Halo\ install folder where halo.exe is located.
 4) Edit alsoft.ini and copy & paste these settings:
 ```
- [general]
+[general]
 channels=stereo
 frequency=48000
 stereo-mode=headphones
@@ -78,39 +80,39 @@ boost=-6
 ```
 ### chimera
 
-Chimera passively increases animation framerate, corrects some fog, boosts polygon limit, object limit, and draw distance. Highly recommended for comfort and bug fixes alone.
+Chimera passively increases animation framerate, corrects some fog, boosts polygon limit, object limit, and draw distance, but is highly recommended for bug fixes and QOL changes alone.
 
-See installation instructions above. If you installed chimera, you can execute commands to reduce pop-in and low detail models (lods), turn on anisotrophic filtering for sharper textures on world geometry, and turn on reverberation for first person sounds (requires dsoal). These are not turned on by default. There are several ways to do this. Please read about all 3 methods before proceeding.
+See installation instructions above. If you installed chimera, you can execute console commands to reduce pop-in and low detail models (lods), turn on anisotrophic filtering for sharper textures on world geometry, and turn on reverberation for first person sounds (requires dsoal). These are not turned on by default. There are several ways to do this. Please read about all 3 methods before proceeding.
 
-To launch the game in flat mode and use the console with the tilde ~ key, you can disable the VR mod by temporarily renaming d3d9.dll to something like d3d9aa.dll. However executed console commands are saved and read from/to a text file, which you can navigate to and edit directly instead.
+* To launch the game in flat mode and use the console with the tilde ~ key, you can disable the VR mod by temporarily renaming d3d9.dll to something like d3d9aa.dll. 
 
-Go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands:
+* However, executed console commands are saved and read from a text file, it might be easier to edit this file directly instead. After running Halo once with chimera installed, close Halo and go to (Your User Folder)\Documents\My Games\Halo\chimera\preferences.txt, and add these commands:
 ```
 chimera_model_detail 8
 chimera_af 1
 chimera_fp_reverb 1
 ```
-If you want these preferences to be portable and travel with your Halo installation:
+* If you want these preferences to be portable and travel with your Halo installation:
 
-1) Create a new text file named chimera_preferences.txt in the \Halo\ folder along side chimera.ini
-2) edit \Halo\chimera.ini
-3) Do not paste the commands into chimera.ini, some of them will not work
+1) Create a new text file named chimera_preferences.txt in the Halo\ folder alongside chimera.ini
+2) edit Halo\chimera.ini
+3) Do not paste the commands into chimera.ini, some of them will not work.
 5) chimera.ini comments(disables) lines with a semi-colon ```;```. Find ```exec=``` and remove any semi-colon on that line, such as ```;exec=```
 6) set the value to ```exec=./chimera_preferences.txt```
 7) paste the commands listed above into chimera_preferences.txt
 
 ### Halo Refined
 
-When Halo was ported to PC in 2003, many graphical effects present in the original Xbox version were broken and outdated assets were accidentally used. Halo Refined is a community project that fixes many issues such as invisible bumpmapping, missing specular, broken transparency effects, etc and provides some faithful high resolution assets by replacing Halo's map files.
+A Community project that restores many graphical effects present in the original Xbox version by replacing Halo's map files. Fixes issues such as invisible bumpmapping, missing specular, broken transparency effects, etc. Also provides some high res asset replacements, most notably an HD HUD. 
 
 Halo Refined is poorly tested with HaloCEVR but seems to work, recommended for experimental use. Please keep back ups of your original .map files before installing. If you are having any issues with HaloCEVR while using Refined's maps, restore the original files and retest before reporting your issue.
 
-Recent versions require chimera. Refined is designed with dgVoodoo2 and CEnshine in mind to fix even more effects, but these are tools and modifications can't be used with HaloCEVR. CEnshine is for Custom Edition only which HaloCEVR does not currently support.
+Recent versions require chimera. Refined is designed with dgVoodoo2 and CEnshine in mind to fix even more effects, but these are tools and modifications can't be used with HaloCEVR. 
 
 1) Download and extract the latest distribution for Retail, not Custom Edition
-2) Backup all files in \Halo\maps\
-3) Replace files in \Halo\maps\
-4) (Optional) Read \Halo\maps\info.txt
+2) Backup all files in Halo\maps\ by copying them to a different location
+3) Replace files in Halo\maps\
+4) (Optional) Read Halo\maps\info.txt
 
 Download, updated as of the time of writing:
 https://www.proxeninc.net/Halo/Refined/


### PR DESCRIPTION
I wanted to sell users on installing enhancements like dsoal and chimera after the base install, because I waited too long into the campaign to try them out myself and regret it. I've also added a new section for Halo Refined because it's a great fix mod and I can't imagine allowing someone to play the vanilla gearbox port without saying something. But obviously you'll want to take a hard look at that section before approving it. The whole thing is verbose and too formal compared to the rest of the readme but that's just me unfortunately.

Smaller things to check out:

---

I clarified that dsoal and chimera require one another for reverb on first person sounds, and that first person sounds have no stereo/HRTF/location effects. I'd ask if this is hard to implement but I know the answer is yes.

---

I added `hrtf-mode = full` to alsoft.ini config but I'm wondering if it was left out for a reason. I did include a cautionary note though. I have a 5800X3D so I'm not fit to judge what's ok for the average system. Here is the official description:

```
Specifies the rendering mode for HRTF processing. Setting the mode to full
#  (default) applies a unique HRIR filter to each source given its relative
#  location, providing the clearest directional response at the cost of the
#  highest CPU usage. Setting the mode to ambi1, ambi2, or ambi3 will instead
#  mix to a first-, second-, or third-order ambisonic buffer respectively, then
#  decode that buffer with HRTF filters. Ambi1 has the lowest CPU usage,
#  replacing the per-source HRIR filter for a simple 4-channel panning mix, but
#  retains full 3D placement at the cost of a more diffuse response. Ambi2 and
#  ambi3 increasingly improve the directional clarity, at the cost of more CPU
#  usage (still less than "full", given some number of active sources).
```

---

I couldn't find `chimera_lod` in chimera's current documentation and the console refused the command. I'm assuming it's old and has been obsoleted by `chimera_model_detail` which sounds like it does the same thing, so it has been removed from the guide. 

I put an emphasis on just activating `chimera_model_detail 8` with the in-game console because it is easy, and added a new method of creating a user preferences file where it is normally generated. `exec=` path is the slowest method with the most steps so I put it last, but I changed the instructions to search for preferences in the same directory so it works on portable installs.