### PR TITLE
Seems to make the UI 4:3 so it's aspect corrected

### DIFF
--- a/HaloCEVR/VR/OpenVR.cpp
+++ b/HaloCEVR/VR/OpenVR.cpp
@@ -413,7 +413,7 @@ void OpenVR::PositionOverlay()
 	float yaw = atan2(-mat.m[2][0], mat.m[2][2]);
 	vr::HmdMatrix34_t transform = {
 		cos(yaw), 0, sin(yaw), position.v[0],
-		0, 0.75, 0, position.v[1],
+		0, 0.75f, 0, position.v[1],
 		-sin(yaw), 0, cos(yaw), position.v[2]
 	};
 

--- a/HaloCEVR/VR/OpenVR.cpp
+++ b/HaloCEVR/VR/OpenVR.cpp
@@ -413,7 +413,7 @@ void OpenVR::PositionOverlay()
 	float yaw = atan2(-mat.m[2][0], mat.m[2][2]);
 	vr::HmdMatrix34_t transform = {
 		cos(yaw), 0, sin(yaw), position.v[0],
-		0, 1, 0, position.v[1],
+		0, 0.75, 0, position.v[1],
 		-sin(yaw), 0, cos(yaw), position.v[2]
 	};
 


### PR DESCRIPTION
Seems to make the UI 4:3 from 1:1 to correct the aspect ratio. If 1 sets the height to 100% of the width, 0.75 could be 75% of the width. I was just messing with numbers trying to change something else, and I knew this was a requested fix. I have no idea what I'm doing.

solves silent's issue without breaking the mouse cursor. But it feels too easy so please test

https://github.com/LivingFray/HaloCEVR/pull/33

[HaloCEVR.zip](https://github.com/user-attachments/files/18207855/HaloCEVR.zip)

