### PR TITLE
adds c_UIOverlayRenderScale to replace UIOverlayWidth and Height

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -943,8 +943,9 @@ void Game::SetupConfigs()
 	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay in metres", 10.0f);
 	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay in metres", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 600);
-	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay in pixels", 600);
+	c_UIOverlayRenderScale = config.RegisterFloat("c_UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 0.5f);
+	c_UIOverlayWidth  = new IntProperty( static_cast<int>( std::max( vr->GetViewHeight() , vr->GetViewWidth() ) * c_UIOverlayRenderScale->Value() ) , "" );  // 
+	c_UIOverlayHeight = new IntProperty( static_cast<int>( std::max( vr->GetViewHeight() , vr->GetViewWidth() ) * c_UIOverlayRenderScale->Value() ) , "" ); // = Choose the larger of UIOverlayWidth/Height, then * UIOverlayRenderScale 
 	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Display a floating crosshair in the world at the location you are aiming", true);
 	// Control settings
 	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -947,7 +947,7 @@ void Game::SetupConfigs()
 	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay in metres", 10.0f);
 	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay in metres", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayRenderScale = config.RegisterFloat("c_UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 0.5f);
+	c_UIOverlayRenderScale = config.RegisterFloat("UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 0.5f);
 	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Display a floating crosshair in the world at the location you are aiming", true);
 	// Control settings
 	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -950,7 +950,7 @@ void Game::SetupConfigs()
 	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay in metres", 10.0f);
 	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay in metres", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayRenderScale = config.RegisterFloat("UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 0.5f);
+	c_UIOverlayRenderScale = config.RegisterFloat("UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution), low values default to 640px", 0.5f);
 	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Display a floating crosshair in the world at the location you are aiming", true);
 	// Control settings
 	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -114,6 +114,9 @@ void Game::OnInitDirectX()
 
 	// Ideally these values would be in a 4:3 ratio, but this causes the mouse position to stop aligning correctly
 	overlayWidth = static_cast<UINT>(std::max(vr->GetViewHeight(), vr->GetViewWidth()) * c_UIOverlayRenderScale->Value());
+	if (overlayWidth < 640) { // Clamp low to 640px so user can't degrade/break the config UI 
+		overlayWidth = 640; 
+	}
 	overlayHeight = overlayWidth;
 
 	vr->OnGameFinishInit();

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -27,21 +27,6 @@ void Game::Init()
 {
 	Logger::log << "[Game] HaloCEVR initialising..." << std::endl;
 
-#if USE_PROFILER
-	profiler.Init();
-#endif
-
-	SetupConfigs();
-
-	CreateConsole();
-
-	PatchGame();
-
-	Logger::log << "[Game] Found Game Type: " << Helpers::GetGameTypeString() << std::endl;
-	Logger::log << "[Game] Found Game Version: " << Helpers::GetVersionString() << std::endl;
-
-	bIsCustom = std::strcmp("halor", Helpers::GetGameTypeString()) != 0;
-
 #if EMULATE_VR
 	vr = new VREmulator();
 #else
@@ -56,6 +41,21 @@ void Game::Init()
 	backBufferHeight = vr->GetViewHeight();
 
 	bHasShutdown = false;
+
+#if USE_PROFILER
+	profiler.Init();
+#endif
+
+	SetupConfigs();
+
+	CreateConsole();
+
+	PatchGame();
+
+	Logger::log << "[Game] Found Game Type: " << Helpers::GetGameTypeString() << std::endl;
+	Logger::log << "[Game] Found Game Version: " << Helpers::GetVersionString() << std::endl;
+
+	bIsCustom = std::strcmp("halor", Helpers::GetGameTypeString()) != 0;
 
 	Logger::log << "[Game] HaloCEVR initialised" << std::endl;
 }

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -106,8 +106,8 @@ public:
 
 	bool bIsCustom = false;
 
-	UINT overlayWidth = 600;
-	UINT overlayHeight = 600;
+	UINT overlayWidth = 640;
+	UINT overlayHeight = 640;
 
 #if USE_PROFILER
 	Profiler profiler;

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -194,6 +194,7 @@ public:
 	FloatProperty* c_UIOverlayScale = nullptr;
 	FloatProperty* c_MenuOverlayScale = nullptr;
 	FloatProperty* c_UIOverlayCurvature = nullptr;
+	FloatProperty* c_UIOverlayRenderScale = nullptr;
 	IntProperty* c_UIOverlayWidth = nullptr;
 	IntProperty* c_UIOverlayHeight = nullptr;
 	BoolProperty* c_ShowCrosshair = nullptr;

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -106,6 +106,9 @@ public:
 
 	bool bIsCustom = false;
 
+	UINT overlayWidth = 600;
+	UINT overlayHeight = 600;
+
 #if USE_PROFILER
 	Profiler profiler;
 #endif
@@ -195,8 +198,6 @@ public:
 	FloatProperty* c_MenuOverlayScale = nullptr;
 	FloatProperty* c_UIOverlayCurvature = nullptr;
 	FloatProperty* c_UIOverlayRenderScale = nullptr;
-	IntProperty* c_UIOverlayWidth = nullptr;
-	IntProperty* c_UIOverlayHeight = nullptr;
 	BoolProperty* c_ShowCrosshair = nullptr;
 	BoolProperty* c_SnapTurn = nullptr;
 	FloatProperty* c_SnapTurnAmount = nullptr;

--- a/HaloCEVR/Hooking/Hooks.cpp
+++ b/HaloCEVR/Hooking/Hooks.cpp
@@ -824,8 +824,8 @@ void Hooks::H_DrawLoadingScreen2(void* param1)
 	{
 		0,
 		0,
-		static_cast<DWORD>(Game::instance.c_UIOverlayWidth->Value()),
-		static_cast<DWORD>(Game::instance.c_UIOverlayHeight->Value()),
+		static_cast<DWORD>(Game::instance.overlayWidth),
+		static_cast<DWORD>(Game::instance.overlayHeight),
 		0.0f,
 		1.0f
 	};
@@ -845,8 +845,8 @@ void Hooks::H_DrawCinematicBars()
 	{
 		0,
 		0,
-		static_cast<DWORD>(Game::instance.c_UIOverlayWidth->Value()),
-		static_cast<DWORD>(Game::instance.c_UIOverlayHeight->Value()),
+		static_cast<DWORD>(Game::instance.overlayWidth),
+		static_cast<DWORD>(Game::instance.overlayHeight),
 		0.0f,
 		1.0f
 	};

--- a/HaloCEVR/UI/UIRenderer.cpp
+++ b/HaloCEVR/UI/UIRenderer.cpp
@@ -22,8 +22,8 @@ void UIRenderer::Init(IDirect3DDevice9* inDevice)
 	InitFont("VR/Fonts/italics.ttf", 18.0f, fontDesc);
 
 	// Assume the UI is rendering on a 640x480 canvas and just scale everything accordingly
-	widthScale = Game::instance.c_UIOverlayWidth->Value() / 640.0f;
-	heightScale = Game::instance.c_UIOverlayHeight->Value() / 480.0f;
+	widthScale = Game::instance.overlayWidth / 640.0f;
+	heightScale = Game::instance.overlayHeight / 480.0f;
 }
 
 bool UIRenderer::InitFont(const char* fontPath, float fontSize, Font& outFont)

--- a/HaloCEVR/VR/OpenVR.cpp
+++ b/HaloCEVR/VR/OpenVR.cpp
@@ -189,8 +189,8 @@ void OpenVR::OnGameFinishInit()
 	CreateTexAndSurface(0, recommendedWidth, recommendedHeight, desc.Usage, desc.Format);
 	CreateTexAndSurface(1, recommendedWidth, recommendedHeight, desc.Usage, desc.Format);
 	// UI Layers
-	CreateTexAndSurface(uiSurface, Game::instance.c_UIOverlayWidth->Value(), Game::instance.c_UIOverlayHeight->Value(), desc2.Usage, desc2.Format);
-	CreateTexAndSurface(crosshairSurface, Game::instance.c_UIOverlayWidth->Value(), Game::instance.c_UIOverlayHeight->Value(), desc2.Usage, desc2.Format);
+	CreateTexAndSurface(uiSurface, Game::instance.overlayWidth, Game::instance.overlayHeight, desc2.Usage, desc2.Format);
+	CreateTexAndSurface(crosshairSurface, Game::instance.overlayWidth, Game::instance.overlayHeight, desc2.Usage, desc2.Format);
 	scopeWidth = static_cast<uint32_t>(Game::instance.c_ScopeRenderScale->Value() * recommendedWidth);
 	scopeHeight = static_cast<uint32_t>(Game::instance.c_ScopeRenderScale->Value() * recommendedWidth * 0.75f); // Maintain the 4x3 aspect ratio halo works best with
 	CreateTexAndSurface(scopeSurface, scopeWidth, scopeHeight, desc2.Usage, desc2.Format);

--- a/HaloCEVR/VR/VREmulator.cpp
+++ b/HaloCEVR/VR/VREmulator.cpp
@@ -483,7 +483,7 @@ void VREmulator::CreateSharedTarget()
 	CreateTexAndSurface(0, width, height, desc.Usage, desc.Format);
 	CreateTexAndSurface(1, width, height, desc.Usage, desc.Format);
 
-	HRESULT res = Helpers::GetDirect3DDevice9()->CreateTexture(Game::instance.c_UIOverlayWidth->Value(), Game::instance.c_UIOverlayHeight->Value(), 1, desc2.Usage, desc2.Format, D3DPOOL_DEFAULT, &uiTexture, NULL);
+	HRESULT res = Helpers::GetDirect3DDevice9()->CreateTexture(Game::instance.overlayWidth, Game::instance.overlayHeight, 1, desc2.Usage, desc2.Format, D3DPOOL_DEFAULT, &uiTexture, NULL);
 
 	if (FAILED(res))
 	{
@@ -497,7 +497,7 @@ void VREmulator::CreateSharedTarget()
 		Logger::log << "Couldn't create UI render target: " << res << std::endl;
 	}
 
-	res = Helpers::GetDirect3DDevice9()->CreateTexture(Game::instance.c_UIOverlayWidth->Value(), Game::instance.c_UIOverlayHeight->Value(), 1, desc2.Usage, desc2.Format, D3DPOOL_DEFAULT, &crosshairTexture, NULL);
+	res = Helpers::GetDirect3DDevice9()->CreateTexture(Game::instance.overlayWidth, Game::instance.overlayHeight, 1, desc2.Usage, desc2.Format, D3DPOOL_DEFAULT, &crosshairTexture, NULL);
 
 	if (FAILED(res))
 	{


### PR DESCRIPTION
Just to set expectations, I took C++ over 10 years ago and I wasn't good at it. This pull request doesn't work and I needed some help.

I set out to make the Overlay UI adjustable like ScopeRenderScale where the resolution is based on your headset's resolution instead of some arbitrary(?) value like 600x600. I don't know if that resolution was chosen for a good reason but I've been using a higher resolution with no noticeable consequence. 600x600 has bad aliasing even with halo pc's low resolution hud. Also the new VR config menu has bad font rendering unless you turn it up. Something between 1/2 and full resolution of the headset seems useful. Also with the aspect ratio being fixed, I can't think of a reason to expose the width and height numbers independently unless the current aspect ratio fix is hackey, and the mouse needs to be fixed when using 4:3 numbers instead.

Anyway I need help fixing my implementation. c_UIOverlayWidth and c_UIOverlayHeight are no longer registered in the config, but they are where all the config variables are which looks messy. So I made unreadable code to fit on one line each.

```
	c_UIOverlayRenderScale = config.RegisterFloat("c_UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 0.5f);
	c_UIOverlayWidth  = new IntProperty( static_cast<int>( std::max( vr->GetViewHeight() , vr->GetViewWidth() ) * c_UIOverlayRenderScale->Value() ) , "" );  // 
	c_UIOverlayHeight = new IntProperty( static_cast<int>( std::max( vr->GetViewHeight() , vr->GetViewWidth() ) * c_UIOverlayRenderScale->Value() ) , "" ); // = Choose the larger of UIOverlayWidth/Height, then * UIOverlayRenderScale 
```

I set UIOverlayWidth/Height here because I wanted to get to it before anything used it. I don't know where it would belong in the code. Maybe **Game::PreDrawHUD()** ?

I also had to move **vr->Init()** before **SetupConfigs()** in **Game::Init()** to even make this run. There's no way that doesn't break something somewhere. But is that helpful? I'm not sure how you would use information about the user's VR in the config otherwise.

And finally changing c_UIOverlayRenderScale doesn't work. It sticks to the default and doesn't get updated.

