### PR TITLE
Implement feature to lock roll axis of scopes

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -967,6 +967,7 @@ void Game::SetupConfigs()
 	c_ControllerRotation = config.RegisterVector3("ControllerRotation", "Rotation added to the controller when calculating the in game hand rotation", Vector3(0.0f, 0.0f, 0.0f));
 	c_ScopeRenderScale = config.RegisterFloat("ScopeRenderScale", "Size of the scope render target, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 1.0f);
 	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view in metres", 0.05f);
+	c_LockScopeRoll = config.RegisterBool("LockScopeRoll", "Set to true to keep the horizon level at all times in scopes. Leaving as false causes the scope view to rotate with the gun", false);
 	c_ScopeOffsetPistol = config.RegisterVector3("ScopeOffsetPistol", "Offset of the scope view relative to the pistol's location", Vector3(-0.1f, 0.0f, 0.15f));
 	c_ScopeOffsetSniper = config.RegisterVector3("ScopeOffsetSniper", "Offset of the scope view relative to the pistol's location", Vector3(-0.15f, 0.0f, 0.15f));
 	c_ScopeOffsetRocket = config.RegisterVector3("ScopeOffsetRocket", "Offset of the scope view relative to the pistol's location", Vector3(0.1f, 0.2f, 0.1f));

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -215,6 +215,7 @@ public:
 	Vector3Property* c_ControllerRotation = nullptr;
 	FloatProperty* c_ScopeRenderScale = nullptr;
 	FloatProperty* c_ScopeScale = nullptr;
+	BoolProperty* c_LockScopeRoll = nullptr;
 	Vector3Property* c_ScopeOffsetPistol = nullptr;
 	Vector3Property* c_ScopeOffsetSniper = nullptr;
 	Vector3Property* c_ScopeOffsetRocket = nullptr;

--- a/HaloCEVR/WeaponHandler.cpp
+++ b/HaloCEVR/WeaponHandler.cpp
@@ -745,7 +745,11 @@ bool WeaponHandler::GetLocalWeaponScope(Vector3& outPosition, Vector3& outAim, V
 
 	outPosition = gunOffset + finalRot * scopeOffset;
 	outAim = finalRot * Vector3(1.0f, 0.0f, 0.0f);
-	upDir = finalRot * Vector3(0.0f, 0.0f, 1.0f);
+
+	upDir = Vector3(0.0f, 0.0f, 1.0f);
+	if (!Game::instance.c_LockScopeRoll->Value()) {
+		upDir = finalRot * upDir;
+	}
 
 #if DRAW_DEBUG_AIM
 	// N.b. - This function is in local (i.e. vr) coordinate space, convert to world for debug to be correct


### PR DESCRIPTION
Adds an option to lock the roll axis of a scoped weapon when zoomed in, meaning that the horizon will stay level within your scope at all times. This option is turned off by default, so there will be no change to gameplay for most users. Tested by launching the game with and without this feature enabled, and confirming the unchanged vs. new behavior depending on the flag.