### PR TITLE
Adds user configurable arc scale (proportion of fov) to replace actual scale for UI, crosshair, and menu

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -120,6 +120,11 @@ void Game::OnInitDirectX()
 	}
 	overlayHeight = overlayWidth;
 
+	// Calculate UI element sizes with config defined distance and arc size
+	uiOverlayScale = std::tanf(c_UIOverlayArcScale->Value() / 2 * 3.141593f / 180) * c_UIOverlayDistance->Value() * 2;
+	crosshairScale = std::tanf(c_CrosshairArcScale->Value() / 2 * 3.141593f / 180) * c_CrosshairDistance->Value() * 2;
+	menuOverlayScale = std::tanf(c_MenuOverlayArcScale->Value() / 2 * 3.141593f / 180) * c_MenuOverlayDistance->Value() * 2;
+
 	vr->OnGameFinishInit();
 
 	uiSurface = vr->GetUISurface();
@@ -950,9 +955,9 @@ void Game::SetupConfigs()
 	c_CrosshairDistance = config.RegisterFloat("CrosshairDistance", "Distance in metres in front of the weapon to display the crosshair", 15.0f);
 	c_MenuOverlayDistance = config.RegisterFloat("MenuOverlayDistance", "Distance in metres in front of the HMD to display the menu", 15.0f);
 	c_UIOverlayDistance = config.RegisterFloat("UIOverlayDistance", "Distance in metres in front of the HMD to display the UI", 15.0f);
-	c_UIOverlayScale = config.RegisterFloat("UIOverlayScale", "Width of the UI overlay in metres", 10.0f);
-	c_MenuOverlayScale = config.RegisterFloat("MenuOverlayScale", "Width of the menu overlay in metres", 10.0f);
-	c_CrosshairScale = config.RegisterFloat("CrosshairScale", "Width of the crosshair overlay in metres", 10.0f);
+	c_UIOverlayArcScale = config.RegisterFloat("UIOverlayArcScale", "Width of the UI overlay in degrees as a proportion of FOV", 45.0f);
+	c_MenuOverlayArcScale = config.RegisterFloat("MenuOverlayArcScale", "Width of the menu overlay in degrees as a proportion of FOV", 45.0f);
+	c_CrosshairArcScale = config.RegisterFloat("CrosshairArcScale", "Size of the crosshair overlay in degrees as a proportion of FOV, values are relative and not actual", 35.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
 	c_UIOverlayRenderScale = config.RegisterFloat("UIOverlayRenderScale", "Resolution of the UI overlay, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution), low values default to 640px", 0.5f);
 	c_ShowCrosshair = config.RegisterBool("ShowCrosshair", "Display a floating crosshair in the world at the location you are aiming", true);

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -110,6 +110,10 @@ public:
 	UINT overlayWidth = 640;
 	UINT overlayHeight = 640;
 
+	float uiOverlayScale = 10.0f;
+	float crosshairScale = 10.0f;
+	float menuOverlayScale = 10.0f;
+
 #if USE_PROFILER
 	Profiler profiler;
 #endif
@@ -192,11 +196,11 @@ public:
 	BoolProperty* c_DrawMirror = nullptr;
 	IntProperty* c_MirrorEye = nullptr;
 	FloatProperty* c_CrosshairDistance = nullptr;
-	FloatProperty* c_CrosshairScale = nullptr;
+	FloatProperty* c_CrosshairArcScale = nullptr;
 	FloatProperty* c_MenuOverlayDistance = nullptr;
 	FloatProperty* c_UIOverlayDistance = nullptr;
-	FloatProperty* c_UIOverlayScale = nullptr;
-	FloatProperty* c_MenuOverlayScale = nullptr;
+	FloatProperty* c_UIOverlayArcScale = nullptr;
+	FloatProperty* c_MenuOverlayArcScale = nullptr;
 	FloatProperty* c_UIOverlayCurvature = nullptr;
 	FloatProperty* c_UIOverlayRenderScale = nullptr;
 	BoolProperty* c_ShowCrosshair = nullptr;

--- a/HaloCEVR/VR/OpenVR.cpp
+++ b/HaloCEVR/VR/OpenVR.cpp
@@ -197,12 +197,12 @@ void OpenVR::OnGameFinishInit()
 
 	vr::EVROverlayError err;
 
-	err = vrOverlay->SetOverlayWidthInMeters(uiOverlay, Game::instance.c_UIOverlayScale->Value());
+	err = vrOverlay->SetOverlayWidthInMeters(uiOverlay, Game::instance.uiOverlayScale);
 	if (err != vr::VROverlayError_None)
 	{
 		Logger::log << "[OpenVR] Error setting overlay width: " << err << std::endl;
 	}
-	Logger::log << "[OpenVR] Set UI Width = " << Game::instance.c_UIOverlayScale->Value() << std::endl;
+	Logger::log << "[OpenVR] Set UI Width = " << Game::instance.uiOverlayScale << std::endl;
 
 	float curvature = Game::instance.c_UIOverlayCurvature->Value();
 	if (curvature != 0.0f)
@@ -770,7 +770,7 @@ void OpenVR::SetMouseVisibility(bool bIsVisible)
 	}
 
 	vrOverlay->SetOverlayInputMethod(uiOverlay, bIsVisible ? vr::VROverlayInputMethod_Mouse : vr::VROverlayInputMethod_None);
-	vrOverlay->SetOverlayWidthInMeters(uiOverlay, bIsVisible ? Game::instance.c_MenuOverlayScale->Value() : Game::instance.c_UIOverlayScale->Value());
+	vrOverlay->SetOverlayWidthInMeters(uiOverlay, bIsVisible ? Game::instance.menuOverlayScale : Game::instance.uiOverlayScale);
 }
 
 void OpenVR::SetCrosshairTransform(Matrix4& newTransform)
@@ -782,7 +782,7 @@ void OpenVR::SetCrosshairTransform(Matrix4& newTransform)
 	Vector3 pos = (newTransform * Vector3(0.0f, 0.0f, 0.0f)) * Game::instance.MetresToWorld(1.0f) + Helpers::GetCamera().position;
 	Matrix3 rot;
 	Vector2 size(1.33f, 1.0f);
-	size *= Game::instance.MetresToWorld(Game::instance.c_CrosshairScale->Value());
+	size *= Game::instance.MetresToWorld(Game::instance.crosshairScale);
 
 	newTransform.translate(-pos);
 	newTransform.rotate(90.0f, newTransform.getLeftAxis());


### PR DESCRIPTION
First time pushing from visual studio, I just clicked things until it worked, I hope everything went ok

This PR has users configure the desired UI, crosshair, and menu sizes in degrees as a proportion of FOV rather than adjusting the actual sizes of the UI elements. This means if the user just wants to change the distance on any of these, they don't have to adjust the size afterwards to compensate, which requires trig to do accurately as far as I can tell.

In my testing the only thing that might not work as expected is 100 degrees was outside my quest 2's fov more than my expectation, this is with the face gasket off. But that's a complicated topic so I have no real reason to suspect something is amiss there.

What I don't like about this PR is I couldn't figure out how to not require a restart for these changes like the distance settings currently work, which would cut down the user time waste on trial and error. Even if I made this a function and ran this somewhere such as after a VR settings menu config change, it would just update uiOverlayScale, crosshairScale, and menuOverlayScale and they wouldn't be put into use until after the game is restarted right? 

I also had a question about defaults because I'm making new config variables. If we decided on different defaults in the future, do users still have to delete their config.txt to activate the new defaults? Say they generated a config file for c_UIOverlayArcScale=45.0 in the next release, then for a release after that we decide 55 is better. How do we tell the difference between a user preference and old defaults?

Thanks