### PR TITLE
Fix vector3 setting menu reading all three members

### DIFF
--- a/HaloCEVR/UI/SettingsMenu.cpp
+++ b/HaloCEVR/UI/SettingsMenu.cpp
@@ -305,13 +305,13 @@ UIPanel* SettingsMenu::GenerateSettingsPanel(std::string propertyName, class UIP
 
 		buttonY->onClick = [vectorProperty, buttonY]() {
 			Vector3 value = vectorProperty->Value();
-			value.x = buttonY->floatValue;
+			value.y = buttonY->floatValue;
 			vectorProperty->SetValue(value);
 		};
 
 		buttonZ->onClick = [vectorProperty, buttonZ]() {
 			Vector3 value = vectorProperty->Value();
-			value.x = buttonZ->floatValue;
+			value.z = buttonZ->floatValue;
 			vectorProperty->SetValue(value);
 		};
 


### PR DESCRIPTION
Vector based custom settings weren't taking values as I was expecting so I went poking around and noticed this typo. What do you think?