### PR TITLE
Add a simple 3DOF aiming mode

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -50,6 +50,7 @@ void Game::Init()
 	vr->Init();
 
 	Game::instance.bLeftHanded = Game::instance.c_LeftHanded->Value();
+	Game::instance.bUse3DOFAiming = Game::instance.c_Use3DOFAiming->Value();
 	inputHandler.RegisterInputs();
 
 	backBufferWidth = vr->GetViewWidth();
@@ -396,7 +397,11 @@ void Game::PostDrawScope(Renderer* renderer, float deltaTime)
 		innerSize = Vector2(scopeWidth, scopeHeight);
 	}
 
-	scopeRenderer.DrawInvertedShape2D(centre, innerSize, size, sides, radius, color);
+	// For 3DOF we want to show more of the original scope graphics
+	if (!bUse3DOFAiming)
+	{
+		scopeRenderer.DrawInvertedShape2D(centre, innerSize, size, sides, radius, color);
+	}
 
 	scopeRenderer.Render(Helpers::GetDirect3DDevice9());
 	scopeRenderer.PostRender();
@@ -757,6 +762,10 @@ void Game::PostThrowGrenade(HaloID& playerID)
 void Game::UpdateInputs()
 {
 	VR_PROFILE_SCOPE(Game_UpdateInputs);
+
+	// Hot reload this flag
+	bUse3DOFAiming = c_Use3DOFAiming->Value();
+
 	inputHandler.UpdateInputs(bInVehicle);
 
 #if USE_PROFILER
@@ -977,7 +986,7 @@ void Game::SetupConfigs()
 	c_ControllerOffset = config.RegisterVector3("ControllerOffset", "Offset from the controller's position used when calculating the in game hand position", Vector3(0.0f, 0.0f, 0.0f));
 	c_ControllerRotation = config.RegisterVector3("ControllerRotation", "Rotation added to the controller when calculating the in game hand rotation", Vector3(0.0f, 0.0f, 0.0f));
 	c_ScopeRenderScale = config.RegisterFloat("ScopeRenderScale", "Size of the scope render target, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 1.0f);
-	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view in metres", 0.05f);
+	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view in metres (6DOF mode)", 0.05f);	
 	c_LockScopeRoll = config.RegisterBool("LockScopeRoll", "Set to true to keep the horizon level at all times in scopes. Leaving as false causes the scope view to rotate with the gun (pre-v1.3.0 behaviour)", true);
 	c_ScopeOffsetPistol = config.RegisterVector3("ScopeOffsetPistol", "Offset of the scope view relative to the pistol's location", Vector3(-0.1f, 0.0f, 0.15f));
 	c_ScopeOffsetSniper = config.RegisterVector3("ScopeOffsetSniper", "Offset of the scope view relative to the pistol's location", Vector3(-0.15f, 0.0f, 0.15f));
@@ -985,6 +994,10 @@ void Game::SetupConfigs()
 	c_WeaponSmoothingAmountNoZoom = config.RegisterFloat("UnzoomedWeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when not zoomed in (0 is disabled, 2.0 is maximum, recommended around 0-0.7)", 0.0f);
 	c_WeaponSmoothingAmountOneZoom = config.RegisterFloat("Zoom1WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in once, eg zooming on the pistol (0 is disabled, 2.0 is maximum, recommended around 0.3-1.0)", 0.4f);
 	c_WeaponSmoothingAmountTwoZoom = config.RegisterFloat("Zoom2WeaponSmoothingAmount", "Amount of smoothing applied to weapon movement when zoomed in twice, eg second zoom on sniper (0 is disabled, 2.0 is maximum, recommended around 0.6-1.25)", 0.6f);
+	c_Use3DOFAiming = config.RegisterBool("Use3DOFAiming", "Use controller rotation only for aiming (3DOF) instead of position+rotation (6DOF). When enabled, weapon models follow hand position but bullets fire based on controller rotation only", false);
+	c_3DOFWeaponOffset = config.RegisterVector3("3DOFWeaponOffset", "This is a cosmetic setting for the position offset for the 3DOF weapon model. This has no impact on gameplay. (right, forward, up in metres). Use negative Z to lower the weapon", Vector3(0.0f, 0.0f, -0.08f));
+	c_3DOFWeaponSmoothingAmount = config.RegisterFloat("3DOFWeaponSmoothingAmount", "This is a cosmetic setting that controls the amount of smoothing applied to 3DOF weapon facing direction. This has no impact on gameplay. (0 is disabled, 2.0 is maximum, default is 1.5)", 1.5f);
+	c_3DOFScopeScale = config.RegisterFloat("3DOFScopeScale", "Width of the scope view in metres (3DOF mode)", 7.f);
 	// Weapon holster settings
 	c_EnableWeaponHolsters = config.RegisterBool("EnableWeaponHolsters", "When enabled Weapons can only be switched by using the 'SwitchWeapons' binding while the dominant hand is within distance of a holster", true);
 	c_LeftShoulderHolsterActivationDistance = config.RegisterFloat("LeftShoulderHolsterDistance", "The 'size' of the left shoulder holster. This is the distance that the dominant hand needs to be from the holster to change weapons (<0 to disable)", 0.3f);
@@ -1188,7 +1201,21 @@ void Game::UpdateCrosshairAndScope()
 
 	short zoom = Helpers::GetInputData().zoomLevel;
 
-	bool bHasScope = (zoom != -1) && weaponHandler.GetLocalWeaponScope(aimPos, aimDir, upDir);
+	bool bHasScope;
+	Vector3 scopePos;
+
+	if (bUse3DOFAiming)
+	{
+		// 3DOF MODE: Position scope at crosshair location (targetPos)
+		bHasScope = (zoom != -1);
+		scopePos = targetPos;
+	}
+	else
+	{
+		// 6DOF MODE: Use weapon scope position (original behavior)
+		bHasScope = (zoom != -1) && weaponHandler.GetLocalWeaponScope(aimPos, aimDir, upDir);
+		scopePos = aimPos;
+	}
 
 	if (!bHasScope)
 	{
@@ -1196,10 +1223,10 @@ void Game::UpdateCrosshairAndScope()
 		return;
 	}
 
-	overlayTransform.translate(aimPos);
-	overlayTransform.lookAt(aimPos - aimDir, upDir);
+	overlayTransform.translate(scopePos);
+	overlayTransform.lookAt(scopePos - aimDir, upDir);
 
-	fixupRotation(overlayTransform, aimPos);
+	fixupRotation(overlayTransform, scopePos);
 
 	SetScopeTransform(overlayTransform, true);
 }
@@ -1234,7 +1261,7 @@ void Game::SetScopeTransform(Matrix4& newTransform, bool bIsVisible)
 	inGameRenderer.DrawPolygon(pos, scopeFacing, scopeUp, 32, MetresToWorld(GetScopeSize() * 0.5f), D3DCOLOR_ARGB(0, 0, 0, 0), false);
 
 	float SCOPE_DEPTH = 2.0f;
-	float SCOPE_INNER_SCALE = 80.0f;
+	float SCOPE_INNER_SCALE = bUse3DOFAiming ? 1.6f : 80.0f;
 
 	pos = pos - scopeFacing * MetresToWorld(SCOPE_DEPTH);
 	size *= SCOPE_INNER_SCALE;

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -74,7 +74,7 @@ public:
 
 	ERenderState GetRenderState() const { return renderState; }
 
-	float GetScopeSize() const { return c_ScopeScale->Value(); }
+	float GetScopeSize() const { return bUse3DOFAiming ? c_3DOFScopeScale->Value() : c_ScopeScale->Value(); }
 
 	float MetresToWorld(float m) const;
 	float WorldToMetres(float w) const;
@@ -91,6 +91,7 @@ public:
 	bool bNeedsRecentre = true;
 	bool bUseTwoHandAim = false;
 	bool bLeftHanded = false;
+	bool bUse3DOFAiming = false;
 
 	Config config;
 
@@ -239,5 +240,9 @@ public:
 	FloatProperty* c_TEMPViewportRight = nullptr;
 	FloatProperty* c_TEMPViewportTop = nullptr;
 	FloatProperty* c_TEMPViewportBottom = nullptr;
+	BoolProperty* c_Use3DOFAiming = nullptr;
+	Vector3Property* c_3DOFWeaponOffset = nullptr;
+	FloatProperty* c_3DOFWeaponSmoothingAmount = nullptr;
+	FloatProperty* c_3DOFScopeScale = nullptr;
 };
 

--- a/HaloCEVR/Helpers/Maths.cpp
+++ b/HaloCEVR/Helpers/Maths.cpp
@@ -123,3 +123,26 @@ Vector3 Helpers::Lerp(const Vector3& a, const Vector3& b, float t)
 {
 	return a + t * (b - a);
 }
+
+void Helpers::RotateForSnapTurn(Vector3& vec, float yawDelta, float snapTurnAmount)
+{
+	// 50% threshold to avoid false positives from smooth turning
+	float snapTurnThreshold = snapTurnAmount * 0.5f;
+
+	if (abs(yawDelta) <= snapTurnThreshold)
+		return;
+
+	// Convert degrees to radians, negate for VR system convention
+	const float DEG2RAD = 3.141593f / 180.0f;
+	float yawDeltaRad = -yawDelta * DEG2RAD;
+	float cosTheta = cos(yawDeltaRad);
+	float sinTheta = sin(yawDeltaRad);
+
+	// Apply 2D rotation matrix around Z axis
+	float newX = vec.x * cosTheta - vec.y * sinTheta;
+	float newY = vec.x * sinTheta + vec.y * cosTheta;
+
+	vec.x = newX;
+	vec.y = newY;
+	// Z component unchanged (yaw rotation only)
+}

--- a/HaloCEVR/Helpers/Maths.h
+++ b/HaloCEVR/Helpers/Maths.h
@@ -21,4 +21,5 @@ namespace Helpers
 	void MakeTransformFromQuat(const Vector4* quaternion, Transform* outTransform);
 	void CombineTransforms(const Transform* transformA, const Transform* transformB, Transform* outTransform);
 	Vector3 Lerp(const Vector3& a, const Vector3& b, float t);
+	void RotateForSnapTurn(Vector3& vec, float yawDelta, float snapTurnAmount);
 }

--- a/HaloCEVR/Hooking/Hooks.cpp
+++ b/HaloCEVR/Hooking/Hooks.cpp
@@ -2,6 +2,7 @@
 #include "../Helpers/Player.h"
 #include "../Helpers/Renderer.h"
 #include "../Helpers/DX9.h"
+#include "../Helpers/Cutscene.h"
 #include "../Game.h"
 #include "../Helpers/Menus.h"
 #include "../Helpers/Maths.h"
@@ -862,6 +863,20 @@ void Hooks::H_DrawCinematicBars()
 void Hooks::H_DrawViewModel()
 {
 	VR_PROFILE_SCOPE(Hooks_DrawViewModel);
+
+	// Skip weapon rendering during cutscenes
+	CutsceneData* cutscene = Helpers::GetCutsceneData();
+	if (cutscene && cutscene->bInCutscene)
+	{
+		return;
+	}
+
+	// Skip weapon rendering during scope render in 3DOF mode
+	// This fixes an issue where the weapon model was showing up in the scope
+	if (Game::instance.GetRenderState() == ERenderState::SCOPE && Game::instance.bUse3DOFAiming)
+	{
+		return;
+	}
 
 	if (Game::instance.bLeftHanded)
 	{

--- a/HaloCEVR/InputHandler.h
+++ b/HaloCEVR/InputHandler.h
@@ -17,6 +17,10 @@ public:
 
 	Vector3 smoothedPosition = Vector3(0.0f, 0.0f, 0.0f);
 
+	// Track previous yaw offset to detect snap turns for weapon position smoothing
+	float lastSmoothingYawOffset = 0.0f;
+	bool bLastYawInitialized = false;
+
 protected:
 
 

--- a/HaloCEVR/UI/SettingsMenu.cpp
+++ b/HaloCEVR/UI/SettingsMenu.cpp
@@ -305,13 +305,13 @@ UIPanel* SettingsMenu::GenerateSettingsPanel(std::string propertyName, class UIP
 
 		buttonY->onClick = [vectorProperty, buttonY]() {
 			Vector3 value = vectorProperty->Value();
-			value.x = buttonY->floatValue;
+			value.y = buttonY->floatValue;
 			vectorProperty->SetValue(value);
 		};
 
 		buttonZ->onClick = [vectorProperty, buttonZ]() {
 			Vector3 value = vectorProperty->Value();
-			value.x = buttonZ->floatValue;
+			value.z = buttonZ->floatValue;
 			vectorProperty->SetValue(value);
 		};
 

--- a/HaloCEVR/WeaponHandler.h
+++ b/HaloCEVR/WeaponHandler.h
@@ -65,6 +65,13 @@ protected:
 	Vector3 realPlayerPosition;
 	Vector3 realPlayerAim;
 
+	// Smoothed facing direction for 3DOF mode weapon model
+	Vector3 smoothed3DOFFacingDir = Vector3(1.0f, 0.0f, 0.0f);
+	bool bWasIn3DOFMode = false;
+
+	// Track previous yaw offset to detect snap turns
+	float lastYawOffset = 0.0f;
+
 	// Debug stuff for checking where bullets are coming from/going
 #if DRAW_DEBUG_AIM
 	mutable Vector3 lastFireLocation;


### PR DESCRIPTION
# Pull Request: Add 3DOF Aiming Mode

## Summary
This PR introduces an optional 3DOF aiming mode as an alternative to the existing 6DOF mode. The goal of this mode enable the original weapon animations and scope for players who want to play Halo CE VR in a more casual one-handed aim mode.

## Motivation
While playing this lovely mod on Legendary difficulty, I found myself unable to keep up with the game if I used two-handed grip, or if I swung my arm to melee. The original VR mod allows you to aim one-handed and assign melee to a button press of course, but then I started to miss the Chief's animations for reloading and meleeing.

## Key Features

### Original Weapon Graphics
- Original Halo weapon animations displayed naturally
- Chief's arms anchor under the player's head position
- Cosmetic weapon smoothing applied to the yaw/pitch so we feel the heft of these weapons in Chief's hands

### Casual Scope View
- Positioned the scope at the crosshair so it can be used in a more casual way, and more like the original game
- Made the scope far larger and skipped some of the effects for the VR scope to restore the original scope graphics

### Configuration Options
New config properties:
- `Use3DOFAiming` (bool) - Master toggle to switch between 3DOF and 6DOF modes
- `3DOFWeaponOffset` (Vector3) - I have lowered the weapon graphic slightly to keep the weapon visible but out of the way
- `3DOFWeaponSmoothingAmount` (float, 0-2.0) - There is a heavy smoothing effect, but it is purely cosmetic and doesn't impact where the player is actually aiming.
- `3DOFScopeScale` (float) - Scope width in 3DOF mode

### Notes
- Automatically disables two-handed aiming when 3DOF is active
- Added polish to snap turn which instantly applies the snap delta to the players current aiming direction in **both 6DOF and 3DOF modes**
- Aiming is still 6DOF under the hood
- Settings that works well with this mode are: Assign melee to button (like R3) and disable weapon holster.
- This PR depends on https://github.com/LivingFray/HaloCEVR/pull/136 so I've included a duplicate of that PR in this source. I think it would be better to land that PR first if we like this one and land it after.

### Design Thoughts
- It's almost incorrect to call this a 3DOF mode since the core features here are all cosmetic and not changing how the mod works under the hood. I started on making this a true 3DOF mode by relocating the projectile source to the position of the Chief's gun on the original graphics, but during my testing I rarely noticed or thought about the bullet origin discrepancy. I played through Library and Two Betrayals with this version of this PR and it felt very natural. The little fib to the player that they're still using 6DOF aiming is a problem if they have their controller in their lap and trying to shoot over waist-high cover. I don't articulate to the player that they can simply raise their invisible "gun" to shoot over the cover. If anyone likes this mode I could revisit this. I think I might be the only customer though and I can play around it.

- The larger scope is a feature that could apply to 6DOF mode for some users who like that. It could be extracted from this PR and made a toggle by itself.

- Left handed mode should work, but I've disabled the hot swapping along with the two-handed grip. I wasn't sure the right play here, I'm welcoming feedback. One idea I had was to mirror the Chief's graphics when player swap to left handed mode.