### PR TITLE
Add option for original weapon scope graphics

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -398,8 +398,8 @@ void Game::PostDrawScope(Renderer* renderer, float deltaTime)
 		innerSize = Vector2(scopeWidth, scopeHeight);
 	}
 
-	// For 3DOF we want to show more of the original scope graphics
-	if (!bUse3DOFAiming)
+	// For original scope mode we want to show more of the original scope graphics
+	if (!ShouldUseOriginalScope())
 	{
 		scopeRenderer.DrawInvertedShape2D(centre, innerSize, size, sides, radius, color);
 	}
@@ -1047,6 +1047,7 @@ void Game::SetupConfigs()
 	c_ScopeRenderScale = config.RegisterFloat("ScopeRenderScale", "Size of the scope render target, expressed as a proportion of the headset's render scale (e.g. 0.5 = half resolution)", 1.0f);
 	c_ScopeScale = config.RegisterFloat("ScopeScale", "Width of the scope view in metres (6DOF mode)", 0.05f);	
 	c_LockScopeRoll = config.RegisterBool("LockScopeRoll", "Set to true to keep the horizon level at all times in scopes. Leaving as false causes the scope view to rotate with the gun (pre-v1.3.0 behaviour)", true);
+	c_UseOriginalScope = config.RegisterBool("UseOriginalScope", "Use original Halo scope graphics instead of VR weapon-attached scope. Automatically enabled in 3DOF mode.", false);
 	c_ScopeOffsetPistol = config.RegisterVector3("ScopeOffsetPistol", "Offset of the scope view relative to the pistol's location", Vector3(-0.1f, 0.0f, 0.15f));
 	c_ScopeOffsetSniper = config.RegisterVector3("ScopeOffsetSniper", "Offset of the scope view relative to the pistol's location", Vector3(-0.15f, 0.0f, 0.15f));
 	c_ScopeOffsetRocket = config.RegisterVector3("ScopeOffsetRocket", "Offset of the scope view relative to the pistol's location", Vector3(0.1f, 0.2f, 0.1f));
@@ -1263,15 +1264,15 @@ void Game::UpdateCrosshairAndScope()
 	bool bHasScope;
 	Vector3 scopePos;
 
-	if (bUse3DOFAiming)
+	if (ShouldUseOriginalScope())
 	{
-		// 3DOF MODE: Position scope at crosshair location (targetPos)
+		// Original scope: position at crosshair
 		bHasScope = (zoom != -1);
 		scopePos = targetPos;
 	}
 	else
 	{
-		// 6DOF MODE: Use weapon scope position (original behavior)
+		// VR scope: position at weapon
 		bHasScope = (zoom != -1) && weaponHandler.GetLocalWeaponScope(aimPos, aimDir, upDir);
 		scopePos = aimPos;
 	}
@@ -1320,7 +1321,7 @@ void Game::SetScopeTransform(Matrix4& newTransform, bool bIsVisible)
 	inGameRenderer.DrawPolygon(pos, scopeFacing, scopeUp, 32, MetresToWorld(GetScopeSize() * 0.5f), D3DCOLOR_ARGB(0, 0, 0, 0), false);
 
 	float SCOPE_DEPTH = 2.0f;
-	float SCOPE_INNER_SCALE = bUse3DOFAiming ? 1.6f : 80.0f;
+	float SCOPE_INNER_SCALE = ShouldUseOriginalScope() ? 1.6f : 80.0f;
 
 	pos = pos - scopeFacing * MetresToWorld(SCOPE_DEPTH);
 	size *= SCOPE_INNER_SCALE;

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -75,7 +75,9 @@ public:
 
 	ERenderState GetRenderState() const { return renderState; }
 
-	float GetScopeSize() const { return bUse3DOFAiming ? c_3DOFScopeScale->Value() : c_ScopeScale->Value(); }
+	bool ShouldUseOriginalScope() const { return bUse3DOFAiming || c_UseOriginalScope->Value(); }
+
+	float GetScopeSize() const { return ShouldUseOriginalScope() ? c_3DOFScopeScale->Value() : c_ScopeScale->Value(); }
 
 	float MetresToWorld(float m) const;
 	float WorldToMetres(float w) const;
@@ -245,6 +247,7 @@ public:
 	FloatProperty* c_TEMPViewportTop = nullptr;
 	FloatProperty* c_TEMPViewportBottom = nullptr;
 	BoolProperty* c_Use3DOFAiming = nullptr;
+	BoolProperty* c_UseOriginalScope = nullptr;
 	Vector3Property* c_3DOFWeaponOffset = nullptr;
 	FloatProperty* c_3DOFWeaponSmoothingAmount = nullptr;
 	FloatProperty* c_3DOFScopeScale = nullptr;

--- a/HaloCEVR/Hooking/Hooks.cpp
+++ b/HaloCEVR/Hooking/Hooks.cpp
@@ -871,9 +871,9 @@ void Hooks::H_DrawViewModel()
 		return;
 	}
 
-	// Skip weapon rendering during scope render in 3DOF mode
+	// Skip weapon rendering during scope render when using original scope
 	// This fixes an issue where the weapon model was showing up in the scope
-	if (Game::instance.GetRenderState() == ERenderState::SCOPE && Game::instance.bUse3DOFAiming)
+	if (Game::instance.GetRenderState() == ERenderState::SCOPE && Game::instance.ShouldUseOriginalScope())
 	{
 		return;
 	}


### PR DESCRIPTION
This PR extracts the 3DOF scope mode into its own setting so users can activate it for 6DOF mode as well.

<img width="364" height="352" alt="image" src="https://github.com/user-attachments/assets/f0578c6a-17c0-496c-908a-d1ebce207edb" />

This has a quirk where the scope will draw over the weapon graphics. Though this is technically in line with how the original game's scope took over the entire view. You can see the scope and where your aiming no matter what position you hold the weapon. Welcoming feedback here.
