### PR TITLE
True 3dof aiming with only controller rotation

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -1274,9 +1274,12 @@ void Game::UpdateCrosshairAndScope()
 
 	Matrix4 overlayTransform;
 
-	Vector3 targetPos = aimPos + aimDir * c_CrosshairDistance->Value();
-
 	Vector3 hmdPos = vr->GetHMDTransform(true) * Vector3(0.0f, 0.0f, 0.0f);
+
+	// In 3DOF mode, crosshair projects from HMD position (matching bullet origin)
+	// In 6DOF mode, crosshair projects from controller/weapon position
+	Vector3 crosshairOrigin = bUse3DOFAiming ? hmdPos : aimPos;
+	Vector3 targetPos = crosshairOrigin + aimDir * c_CrosshairDistance->Value();
 
 	overlayTransform.translate(targetPos);
 	overlayTransform.lookAt(hmdPos, Vector3(0.0f, 0.0f, 1.0f));


### PR DESCRIPTION
As a follow up to https://github.com/LivingFray/HaloCEVR/pull/137, this change will make the 3dof mode a true 3dof mode under the hood. The weapon now fires from the HMD position, and uses the controller rotation to aim.

Tested by standing behind waist high cover in the first level, and shooting over it in 3dof mode with the controller in my lap.

Also tested the accuracy of the pistol, scoped pistol, and sniper/scoped sniper. These were pinsharp hitting their marks.

One quirk I noticed is that plasma weapon bullets very obviously fire from your eyeballs. But I think the original game worked this way too?