### PR TITLE
Add optional motion controlled HUD toggle (tap right side of head)

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -1077,6 +1077,7 @@ void Game::SetupConfigs()
 	c_RightHandFlashlightDistance = config.RegisterFloat("RightHandFlashlight", "Bringing the right hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
 	c_HUDToggleDistance = config.RegisterFloat("HUDToggleDistance", "Bringing the dominant hand within this distance of the HUD toggle zone will show/hide the floating HUD (<0 to disable)", -1.0f);
 	c_HUDToggleOffset = config.RegisterVector3("HUDToggleOffset", "The (forward, left, up) Offset of the HUD toggle zone relative to the headset's location. Mirrored horizontally when playing left handed", Vector3(-0.05f, -0.18f, 0.0f));
+	c_HUDToggleSound = config.RegisterString("HUDToggleSound", "Filename of a 16-bit PCM .wav inside the VR folder to play when the HUD is toggled (blank to disable)", "");
 	c_LeftHandMeleeSwingSpeed = config.RegisterFloat("LeftHandMeleeSwingSpeed", "Minimum vertical velocity of left hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_RightHandMeleeSwingSpeed = config.RegisterFloat("RightHandMeleeSwingSpeed", "Minimum vertical velocity of right hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_CrouchHeight = config.RegisterFloat("CrouchHeight", "Minimum height to duck by in metres to automatically trigger the crouch input in game (<0 to disable)", 0.15f);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -520,6 +520,15 @@ bool Game::PreDrawHUD()
 {
 	VR_PROFILE_SCOPE(Game_PreDrawHUD);
 
+	// The HUD toggle gesture has hidden the floating UI layer, so skip drawing it.
+	// This must happen before any state is modified, as returning false means
+	// PostDrawHUD will not be called to restore it. Only the left eye pass is
+	// skipped so the scope and mirror views are unaffected.
+	if (bHideHUD && GetRenderState() == ERenderState::LEFT_EYE)
+	{
+		return false;
+	}
+
 	// Only render UI once per frame
 	if (GetRenderState() != ERenderState::LEFT_EYE)
 	{
@@ -1066,6 +1075,8 @@ void Game::SetupConfigs()
 	c_OffhandHandFlashlight = config.RegisterBool("OffhandHandFlashlight", "Use your offhand for toggling the flashlight, your offhand hand is the hand not holding a weapon", true);
 	c_LeftHandFlashlightDistance = config.RegisterFloat("LeftHandFlashlight", "Bringing the left hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
 	c_RightHandFlashlightDistance = config.RegisterFloat("RightHandFlashlight", "Bringing the right hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
+	c_HUDToggleDistance = config.RegisterFloat("HUDToggleDistance", "Bringing the dominant hand within this distance of the HUD toggle zone will show/hide the floating HUD (<0 to disable)", -1.0f);
+	c_HUDToggleOffset = config.RegisterVector3("HUDToggleOffset", "The (forward, left, up) Offset of the HUD toggle zone relative to the headset's location. Mirrored horizontally when playing left handed", Vector3(-0.05f, -0.18f, 0.0f));
 	c_LeftHandMeleeSwingSpeed = config.RegisterFloat("LeftHandMeleeSwingSpeed", "Minimum vertical velocity of left hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_RightHandMeleeSwingSpeed = config.RegisterFloat("RightHandMeleeSwingSpeed", "Minimum vertical velocity of right hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_CrouchHeight = config.RegisterFloat("CrouchHeight", "Minimum height to duck by in metres to automatically trigger the crouch input in game (<0 to disable)", 0.15f);

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -520,15 +520,6 @@ bool Game::PreDrawHUD()
 {
 	VR_PROFILE_SCOPE(Game_PreDrawHUD);
 
-	// The HUD toggle gesture has hidden the floating UI layer, so skip drawing it.
-	// This must happen before any state is modified, as returning false means
-	// PostDrawHUD will not be called to restore it. Only the left eye pass is
-	// skipped so the scope and mirror views are unaffected.
-	if (bHideHUD && GetRenderState() == ERenderState::LEFT_EYE)
-	{
-		return false;
-	}
-
 	// Only render UI once per frame
 	if (GetRenderState() != ERenderState::LEFT_EYE)
 	{

--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -1066,8 +1066,8 @@ void Game::SetupConfigs()
 	c_OffhandHandFlashlight = config.RegisterBool("OffhandHandFlashlight", "Use your offhand for toggling the flashlight, your offhand hand is the hand not holding a weapon", true);
 	c_LeftHandFlashlightDistance = config.RegisterFloat("LeftHandFlashlight", "Bringing the left hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
 	c_RightHandFlashlightDistance = config.RegisterFloat("RightHandFlashlight", "Bringing the right hand within this distance of the head will toggle the flashlight (<0 to disable)", 0.2f);
-	c_HUDToggleDistance = config.RegisterFloat("HUDToggleDistance", "Bringing the dominant hand within this distance of the HUD toggle zone will show/hide the floating HUD (<0 to disable)", -1.0f);
-	c_HUDToggleOffset = config.RegisterVector3("HUDToggleOffset", "The (forward, left, up) Offset of the HUD toggle zone relative to the headset's location. Mirrored horizontally when playing left handed", Vector3(-0.05f, -0.18f, 0.0f));
+	c_HUDToggleDistance = config.RegisterFloat("HUDToggleDistance", "Bringing the hand opposite the flashlight hand within this distance of the HUD toggle zone will show/hide the floating HUD (<0 to disable)", -1.0f);
+	c_HUDToggleOffset = config.RegisterVector3("HUDToggleOffset", "The (forward, left, up) Offset of the HUD toggle zone relative to the headset's location. Mirrored horizontally to sit beside the hand used for the toggle", Vector3(-0.05f, -0.18f, 0.0f));
 	c_HUDToggleSound = config.RegisterString("HUDToggleSound", "Filename of a 16-bit PCM .wav inside the VR folder to play when the HUD is toggled (blank to disable)", "");
 	c_LeftHandMeleeSwingSpeed = config.RegisterFloat("LeftHandMeleeSwingSpeed", "Minimum vertical velocity of left hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);
 	c_RightHandMeleeSwingSpeed = config.RegisterFloat("RightHandMeleeSwingSpeed", "Minimum vertical velocity of right hand required to initiate a melee attack in m/s (<0 to disable)", 2.5f);

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -225,6 +225,7 @@ public:
 	FloatProperty* c_RightHandFlashlightDistance = nullptr;
 	FloatProperty* c_HUDToggleDistance = nullptr;
 	Vector3Property* c_HUDToggleOffset = nullptr;
+	StringProperty* c_HUDToggleSound = nullptr;
 	BoolProperty* c_EnableWeaponHolsters = nullptr;
 	FloatProperty* c_LeftShoulderHolsterActivationDistance = nullptr;
 	Vector3Property* c_LeftShoulderHolsterOffset = nullptr;

--- a/HaloCEVR/Game.h
+++ b/HaloCEVR/Game.h
@@ -95,6 +95,8 @@ public:
 	bool bNeedsRecentre = true;
 	bool bUseTwoHandAim = false;
 	bool bLeftHanded = false;
+	// Set by the HUD toggle gesture, when true the floating UI layer is not drawn
+	bool bHideHUD = false;
 	bool bUse3DOFAiming = false;
 
 	Config config;
@@ -221,6 +223,8 @@ public:
 	BoolProperty* c_OffhandHandFlashlight = nullptr;
 	FloatProperty* c_LeftHandFlashlightDistance = nullptr;
 	FloatProperty* c_RightHandFlashlightDistance = nullptr;
+	FloatProperty* c_HUDToggleDistance = nullptr;
+	Vector3Property* c_HUDToggleOffset = nullptr;
 	BoolProperty* c_EnableWeaponHolsters = nullptr;
 	FloatProperty* c_LeftShoulderHolsterActivationDistance = nullptr;
 	Vector3Property* c_LeftShoulderHolsterOffset = nullptr;

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -462,25 +462,35 @@ void InputHandler::UpdateHUDToggle()
 
 	IVR* vr = Game::instance.GetVR();
 
-	// Mirror the zone for left handed players so it always sits on the dominant hand's
-	// side of the head (the offset's y axis points left)
+	// Use the opposite hand to the flashlight so the two head gestures never share a
+	// hand. The flashlight uses the offhand when OffhandHandFlashlight is set (the hand
+	// not holding a weapon, i.e. left when right handed), otherwise the dominant hand.
+	bool bFlashlightUsesLeft;
+	if (Game::instance.c_OffhandHandFlashlight->Value())
+	{
+		// Offhand: left for right handed players, right for left handed players
+		bFlashlightUsesLeft = !Game::instance.bLeftHanded;
+	}
+	else
+	{
+		// Dominant hand: right for right handed players, left for left handed players
+		bFlashlightUsesLeft = Game::instance.bLeftHanded;
+	}
+
+	// The HUD toggle uses the inverse hand of the flashlight
+	bool bHUDUsesLeft = !bFlashlightUsesLeft;
+
+	// The offset's y axis points left, so flip it to sit beside whichever hand is used
 	Vector3 offset = Game::instance.c_HUDToggleOffset->Value();
-	if (Game::instance.bLeftHanded)
+	if (bHUDUsesLeft)
 	{
 		offset.y = -offset.y;
 	}
 
 	const Vector3 togglePos = vr->GetHMDTransform() * offset;
 
-	Vector3 handPos;
-	if (Game::instance.bLeftHanded)
-	{
-		handPos = vr->GetRawControllerTransform(ControllerRole::Left) * Vector3(0.0f, 0.0f, 0.0f);
-	}
-	else
-	{
-		handPos = vr->GetRawControllerTransform(ControllerRole::Right) * Vector3(0.0f, 0.0f, 0.0f);
-	}
+	ControllerRole hudHand = bHUDUsesLeft ? ControllerRole::Left : ControllerRole::Right;
+	Vector3 handPos = vr->GetRawControllerTransform(hudHand) * Vector3(0.0f, 0.0f, 0.0f);
 
 	// The hand must leave a larger zone before another toggle can register, otherwise
 	// tracking jitter on the boundary would toggle repeatedly

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -128,6 +128,8 @@ void InputHandler::UpdateInputs(bool bInVehicle)
 		}
 	}
 
+	UpdateHUDToggle();
+
 	if (Game::instance.c_EnableWeaponHolsters->Value())
 	{
 		unsigned char HolsterSwitchWeapons = UpdateHolsterSwitchWeapons();
@@ -415,6 +417,57 @@ unsigned char InputHandler::UpdateFlashlight()
 	}
 
 	return 0;
+}
+
+void InputHandler::UpdateHUDToggle()
+{
+	const float toggleDistance = Game::instance.c_HUDToggleDistance->Value();
+
+	if (toggleDistance <= 0.0f)
+	{
+		bWasTappingHUD = false;
+		return;
+	}
+
+	IVR* vr = Game::instance.GetVR();
+
+	// Mirror the zone for left handed players so it always sits on the dominant hand's
+	// side of the head (the offset's y axis points left)
+	Vector3 offset = Game::instance.c_HUDToggleOffset->Value();
+	if (Game::instance.bLeftHanded)
+	{
+		offset.y = -offset.y;
+	}
+
+	const Vector3 togglePos = vr->GetHMDTransform() * offset;
+
+	Vector3 handPos;
+	if (Game::instance.bLeftHanded)
+	{
+		handPos = vr->GetRawControllerTransform(ControllerRole::Left) * Vector3(0.0f, 0.0f, 0.0f);
+	}
+	else
+	{
+		handPos = vr->GetRawControllerTransform(ControllerRole::Right) * Vector3(0.0f, 0.0f, 0.0f);
+	}
+
+	// The hand must leave a larger zone before another toggle can register, otherwise
+	// tracking jitter on the boundary would toggle repeatedly
+	const float releaseDistance = toggleDistance * 1.5f;
+	const float distanceSqr = (togglePos - handPos).lengthSqr();
+
+	if (!bWasTappingHUD)
+	{
+		if (distanceSqr < toggleDistance * toggleDistance)
+		{
+			bWasTappingHUD = true;
+			Game::instance.bHideHUD = !Game::instance.bHideHUD;
+		}
+	}
+	else if (distanceSqr > releaseDistance * releaseDistance)
+	{
+		bWasTappingHUD = false;
+	}
 }
 
 unsigned char InputHandler::UpdateHolsterSwitchWeapons()

--- a/HaloCEVR/InputHandler.cpp
+++ b/HaloCEVR/InputHandler.cpp
@@ -4,6 +4,12 @@
 #include "Helpers/Camera.h"
 #include "Helpers/Menus.h"
 #include "Helpers/Maths.h"
+#include "Logger.h"
+
+#include <windows.h>
+#include <mmsystem.h>
+// Only used for the HUD toggle sound effect
+#pragma comment(lib, "winmm.lib")
 
 
 #define RegisterBoolInput(set, x) x = vr->RegisterBoolInput(set, #x);
@@ -419,6 +425,31 @@ unsigned char InputHandler::UpdateFlashlight()
 	return 0;
 }
 
+void InputHandler::PlayHUDToggleSound()
+{
+	const std::string& soundFile = Game::instance.c_HUDToggleSound->Value();
+
+	if (soundFile.empty())
+	{
+		return;
+	}
+
+	const std::string soundPath = "VR/" + soundFile;
+
+	// SND_ASYNC returns immediately so we never stall the frame, SND_NODEFAULT stops
+	// Windows playing its default beep if the file is missing or not a valid PCM wav
+	if (!PlaySoundA(soundPath.c_str(), NULL, SND_FILENAME | SND_ASYNC | SND_NODEFAULT))
+	{
+		static bool bWarned = false;
+		if (!bWarned)
+		{
+			bWarned = true;
+			Logger::err << "[HUDToggle] Could not play " << soundPath
+				<< ". Check the file exists and is an uncompressed 16-bit PCM .wav" << std::endl;
+		}
+	}
+}
+
 void InputHandler::UpdateHUDToggle()
 {
 	const float toggleDistance = Game::instance.c_HUDToggleDistance->Value();
@@ -462,6 +493,7 @@ void InputHandler::UpdateHUDToggle()
 		{
 			bWasTappingHUD = true;
 			Game::instance.bHideHUD = !Game::instance.bHideHUD;
+			PlayHUDToggleSound();
 		}
 	}
 	else if (distanceSqr > releaseDistance * releaseDistance)

--- a/HaloCEVR/InputHandler.h
+++ b/HaloCEVR/InputHandler.h
@@ -25,6 +25,7 @@ protected:
 
 
 	unsigned char UpdateFlashlight();
+	void UpdateHUDToggle();
 	unsigned char UpdateHolsterSwitchWeapons();
 	unsigned char UpdateMelee();
 	unsigned char UpdateCrouch();
@@ -42,6 +43,7 @@ protected:
 
 	bool bWasGripping = false;
 	bool bWasSwappingHands = false;
+	bool bWasTappingHUD = false;
 	
 	InputBindingID Jump = 0;
 	InputBindingID SwitchGrenades = 0;

--- a/HaloCEVR/InputHandler.h
+++ b/HaloCEVR/InputHandler.h
@@ -26,6 +26,7 @@ protected:
 
 	unsigned char UpdateFlashlight();
 	void UpdateHUDToggle();
+	void PlayHUDToggleSound();
 	unsigned char UpdateHolsterSwitchWeapons();
 	unsigned char UpdateMelee();
 	unsigned char UpdateCrouch();

--- a/HaloCEVR/VR/OpenVR.cpp
+++ b/HaloCEVR/VR/OpenVR.cpp
@@ -489,12 +489,25 @@ void OpenVR::PostDrawFrame(Renderer* renderer, float deltaTime)
 
 	PositionOverlay();
 
-	vr::Texture_t uiTex{ (void*)vrRenderTexture[uiSurface], vr::TextureType_DirectX, vr::ColorSpace_Auto };
-	vr::EVROverlayError oError = vrOverlay->SetOverlayTexture(uiOverlay, &uiTex);
-
-	if (oError != vr::EVROverlayError::VROverlayError_None)
+	// The HUD toggle gesture hides the floating UI by hiding the overlay rather than
+	// skipping the HUD draw, so the game's HUD logic (including the shield recharge
+	// sound) still runs every frame. The menu shares this overlay, so it is never
+	// hidden while a menu is visible.
+	if (Game::instance.bHideHUD && !bMouseVisible)
 	{
-		Logger::log << "[OpenVR] Could not submit ui texture: " << oError << std::endl;
+		vrOverlay->HideOverlay(uiOverlay);
+	}
+	else
+	{
+		vrOverlay->ShowOverlay(uiOverlay);
+
+		vr::Texture_t uiTex{ (void*)vrRenderTexture[uiSurface], vr::TextureType_DirectX, vr::ColorSpace_Auto };
+		vr::EVROverlayError oError = vrOverlay->SetOverlayTexture(uiOverlay, &uiTex);
+
+		if (oError != vr::EVROverlayError::VROverlayError_None)
+		{
+			Logger::log << "[OpenVR] Could not submit ui texture: " << oError << std::endl;
+		}
 	}
 
 	VR_PROFILE_START(OpenVR_PostPresentHandoff);

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A full VR conversion mod for the original 2003 PC edition of _Halo: Combat Evolv
 * Rebindable controls (with left handed preset available)
 * Motion controlled melee (uses head-aiming)
 * Motion controlled flashlight (tap head)
+* Motion controlled HUD toggle (tap head, disabled by default)
 * Motion controlled crouching
 * Shoulder weapon holsters (for switching weapons)
 * Swapping weapons between hands


### PR DESCRIPTION
Adds a new optional gesture that hides and shows the floating HUD by tapping the side of your head with the dominant hand, in the same spirit as the existing motion controlled flashlight. Handy for screenshots, cutscenes, or just a cleaner view when you don't need the HUD.

Everything is off by default, so a fresh install behaves exactly as it does today. Players opt in through the settings menu or config file.

Behaviour


Bring the dominant hand near a zone beside the head to toggle the floating HUD on or off.
The zone mirrors to the correct side for left handed players.
A short tap is enough — the hand has to move away before it can toggle again, so it won't flicker while your hand lingers near your head.
The scope and desktop mirror views are unaffected.


New settings (these show up automatically in the in game settings menu)


HUDToggleDistance — size of the activation zone. Defaults to -1 (disabled); set a value like 0.15 to turn the gesture on.
HUDToggleOffset — (forward, left, up) position of the zone relative to the headset, so it can be tuned to taste.
HUDToggleSound — optional wav in the VR folder to play on toggle. Blank by default and no audio is bundled, so it's silent unless a player drops in their own file and names it here.


Implementation notes

The HUD is hidden by returning false from Game::PreDrawHUD on the left eye pass, so the original HUD draw is simply skipped rather than drawn and covered up. The gesture reuses the same transform and distance approach as UpdateFlashlight, and picks the dominant hand the same way as the holster code. The optional sound uses PlaySound from winmm, so there's no new audio dependency and a missing or blank file just stays silent.

Roughly 106 lines across Game.h/.cpp, InputHandler.h/.cpp and a README bullet. No new libraries beyond winmm and no bundled assets.

Tested in VR on a Quest 3 using Virtual Desktop confirmed it does nothing at the defaults, toggles correctly once enabled, and that zoom still works while the HUD is hidden.